### PR TITLE
feat: implement multifile upload with tooltip state

### DIFF
--- a/backend/src/brand_guidelines/brand_guideline_controller.py
+++ b/backend/src/brand_guidelines/brand_guideline_controller.py
@@ -76,7 +76,7 @@ async def generate_upload_url(
         )
     if request_dto.size > MAX_UPLOAD_SIZE_BYTES:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"File is too large. Maximum size is {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)}MB.",
         )
 

--- a/backend/src/source_assets/dto/finalize_upload_dto.py
+++ b/backend/src/source_assets/dto/finalize_upload_dto.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydantic import Field
+
+from src.common.base_dto import AspectRatioEnum, BaseDto
+from src.source_assets.schema.source_asset_model import (
+    AssetScopeEnum,
+    AssetTypeEnum,
+)
+
+
+class FinalizeSourceAssetUploadDto(BaseDto):
+    """Request DTO to complete asset registration after successful GCS upload."""
+
+    workspace_id: int = Field(description="The target workspace ID.")
+    gcs_uri: str = Field(
+        description="The gs:// path where the file was uploaded."
+    )
+    filename: str = Field(description="The original filename of the asset.")
+    mime_type: str = Field(description="The MIME type of the asset.")
+    size: int = Field(gt=0, description="The size of the file in bytes.")
+    asset_type: AssetTypeEnum | None = Field(
+        default=None, description="Asset type classification."
+    )
+    aspect_ratio: AspectRatioEnum | None = Field(
+        default=None, description="Aspect ratio of the media asset."
+    )
+    scope: AssetScopeEnum | None = Field(
+        default=None, description="Scope of the asset."
+    )

--- a/backend/src/source_assets/dto/generate_upload_url_dto.py
+++ b/backend/src/source_assets/dto/generate_upload_url_dto.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydantic import Field
+
+from src.common.base_dto import BaseDto
+
+
+class GenerateSourceAssetUploadUrlDto(BaseDto):
+    """Request body to generate a signed URL for direct source asset upload."""
+
+    workspace_id: int = Field(description="The target workspace ID.")
+    filename: str = Field(description="The name of the file to be uploaded.")
+    content_type: str = Field(
+        description="The MIME type of the file (e.g., 'image/png').",
+    )
+    size: int = Field(gt=0, description="The size of the file in bytes.")
+
+
+class GenerateSourceAssetUploadUrlResponseDto(BaseDto):
+    """Response containing the signed URL, GCS URI, and file UUID."""
+
+    upload_url: str = Field(
+        description="The GCS v4 signed URL for the PUT request.",
+    )
+    gcs_uri: str = Field(
+        description="The gs:// path where the file will be stored."
+    )
+    file_uuid: str = Field(
+        description="The generated unique UUID for the upload session."
+    )

--- a/backend/src/source_assets/source_asset_controller.py
+++ b/backend/src/source_assets/source_asset_controller.py
@@ -28,6 +28,13 @@ from fastapi import (
 from src.auth.auth_guard import RoleChecker, get_current_user
 from src.common.base_dto import AspectRatioEnum
 from src.common.dto.pagination_response_dto import PaginationResponseDto
+from src.source_assets.dto.finalize_upload_dto import (
+    FinalizeSourceAssetUploadDto,
+)
+from src.source_assets.dto.generate_upload_url_dto import (
+    GenerateSourceAssetUploadUrlDto,
+    GenerateSourceAssetUploadUrlResponseDto,
+)
 from src.source_assets.dto.source_asset_response_dto import (
     SourceAssetResponseDto,
 )
@@ -42,6 +49,8 @@ from src.users.repository.user_repository import UserRepository
 from src.users.user_model import UserModel, UserRoleEnum
 from src.workspaces.workspace_auth_guard import WorkspaceAuth
 
+MAX_UPLOAD_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB
+
 router = APIRouter(
     prefix="/api/source_assets",
     tags=["User Assets"],
@@ -52,6 +61,77 @@ router = APIRouter(
         ),
     ],
 )
+
+
+# code similar to: backend/src/brand_guidelines/brand_guideline_controller.py
+@router.post(
+    "/generate-upload-url",
+    response_model=GenerateSourceAssetUploadUrlResponseDto,
+    summary="Get a Signed URL for Direct Source Asset Upload",
+)
+async def generate_source_asset_upload_url(
+    request_dto: GenerateSourceAssetUploadUrlDto,
+    current_user: UserModel = Depends(get_current_user),
+    service: SourceAssetService = Depends(),
+    workspace_auth: WorkspaceAuth = Depends(),
+):
+    """Generates a secure, short-lived signed URL to upload a source asset directly to GCS."""
+    await workspace_auth.authorize(
+        workspace_id=request_dto.workspace_id,
+        user=current_user,
+    )
+
+    if request_dto.size > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=f"File is too large. Maximum size is {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)}MB.",
+        )
+
+    allowed_mime_types = {
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "video/mp4",
+        "audio/wav",
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/ogg",
+        "audio/webm",
+    }
+    if request_dto.content_type.lower() not in allowed_mime_types:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported file format.",
+        )
+
+    return await service.generate_signed_upload_url(
+        request_dto=request_dto,
+        current_user=current_user,
+    )
+
+
+@router.post(
+    "/finalize-upload",
+    response_model=SourceAssetResponseDto,
+    status_code=status.HTTP_201_CREATED,
+    summary="Finalize Direct Source Asset Upload",
+)
+async def finalize_source_asset_upload(
+    request_dto: FinalizeSourceAssetUploadDto,
+    current_user: UserModel = Depends(get_current_user),
+    service: SourceAssetService = Depends(),
+    workspace_auth: WorkspaceAuth = Depends(),
+):
+    """Finalizes registration of a source asset in the database after direct GCS upload."""
+    await workspace_auth.authorize(
+        workspace_id=request_dto.workspace_id,
+        user=current_user,
+    )
+
+    return await service.finalize_direct_upload(
+        request_dto=request_dto,
+        current_user=current_user,
+    )
 
 
 @router.post("/upload", response_model=SourceAssetResponseDto)

--- a/backend/src/source_assets/source_asset_service.py
+++ b/backend/src/source_assets/source_asset_service.py
@@ -35,6 +35,13 @@ from src.common.media_utils import generate_thumbnail, get_video_dimensions
 from src.common.storage_service import GcsService
 from src.images.dto.upscale_imagen_dto import UpscaleImagenDto
 from src.images.imagen_service import ImagenService
+from src.source_assets.dto.finalize_upload_dto import (
+    FinalizeSourceAssetUploadDto,
+)
+from src.source_assets.dto.generate_upload_url_dto import (
+    GenerateSourceAssetUploadUrlDto,
+    GenerateSourceAssetUploadUrlResponseDto,
+)
 from src.source_assets.dto.source_asset_response_dto import (
     SourceAssetResponseDto,
 )
@@ -463,6 +470,103 @@ class SourceAssetService:
             scope=final_scope,
             asset_type=final_asset_type,
         )
+        created_asset = await self.repo.create(new_asset)
+        new_asset.id = created_asset.id
+
+        return await self._create_asset_response(new_asset)
+
+    # code similar to: backend/src/brand_guidelines/brand_guideline_service.py
+    async def generate_signed_upload_url(
+        self,
+        request_dto: GenerateSourceAssetUploadUrlDto,
+        current_user: UserModel,
+    ) -> GenerateSourceAssetUploadUrlResponseDto:
+        """Generates a GCS v4 signed URL for a client-side direct source asset upload."""
+        file_uuid = str(uuid.uuid4())
+        destination_blob_name = f"source_assets/{current_user.id}/uploads/{file_uuid}/{request_dto.filename}"
+
+        signed_url, gcs_uri = await asyncio.to_thread(
+            self.iam_signer.generate_v4_upload_signed_url,
+            destination_blob_name,
+            request_dto.content_type,
+            self.gcs_service.bucket_name,
+        )
+
+        if not signed_url or not gcs_uri:
+            raise HTTPException(
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                "Could not generate upload URL.",
+            )
+
+        return GenerateSourceAssetUploadUrlResponseDto(
+            upload_url=signed_url,
+            gcs_uri=gcs_uri,
+            file_uuid=file_uuid,
+        )
+
+    async def finalize_direct_upload(
+        self,
+        request_dto: FinalizeSourceAssetUploadDto,
+        current_user: UserModel,
+    ) -> SourceAssetResponseDto:
+        """Finalizes registration of a source asset uploaded directly to GCS."""
+        content_type = request_dto.mime_type or ""
+        if content_type.startswith("video/"):
+            mime_type_enum = MimeTypeEnum.VIDEO_MP4
+        elif content_type.startswith("audio/"):
+            if content_type in ["audio/mpeg", "audio/mp3"]:
+                mime_type_enum = MimeTypeEnum.AUDIO_MPEG
+            elif content_type == "audio/wav":
+                mime_type_enum = MimeTypeEnum.AUDIO_WAV
+            elif content_type == "audio/ogg":
+                mime_type_enum = MimeTypeEnum.AUDIO_OGG
+            elif content_type == "audio/webm":
+                mime_type_enum = MimeTypeEnum.AUDIO_WEBM
+            else:
+                mime_type_enum = MimeTypeEnum.AUDIO_MPEG
+        else:
+            mime_type_enum = MimeTypeEnum.IMAGE_PNG
+
+        is_admin = UserRoleEnum.ADMIN in current_user.roles
+        final_scope = AssetScopeEnum.PRIVATE
+        if is_admin:
+            final_scope = request_dto.scope or AssetScopeEnum.PRIVATE
+        elif request_dto.scope and request_dto.scope != AssetScopeEnum.PRIVATE:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only administrators can set a non-private scope.",
+            )
+
+        if request_dto.asset_type:
+            final_asset_type = request_dto.asset_type
+        else:
+            if content_type.startswith("video/"):
+                final_asset_type = AssetTypeEnum.GENERIC_VIDEO
+            else:
+                final_asset_type = AssetTypeEnum.GENERIC_IMAGE
+
+        final_aspect_ratio = (
+            request_dto.aspect_ratio or AspectRatioEnum.RATIO_1_1
+        )
+
+        file_hash = hashlib.sha256(
+            request_dto.gcs_uri.encode("utf-8")
+        ).hexdigest()
+
+        new_asset = SourceAssetModel(
+            workspace_id=request_dto.workspace_id,
+            user_id=current_user.id,
+            aspect_ratio=final_aspect_ratio,
+            original_gcs_uri=request_dto.gcs_uri,
+            gcs_uri=request_dto.gcs_uri,
+            thumbnail_gcs_uri=None,
+            original_filename=request_dto.filename or "untitled",
+            mime_type=mime_type_enum,
+            file_hash=file_hash,
+            scope=final_scope,
+            asset_type=final_asset_type,
+        )
+
         created_asset = await self.repo.create(new_asset)
         new_asset.id = created_asset.id
 

--- a/backend/tests/source_assets/test_source_asset_controller.py
+++ b/backend/tests/source_assets/test_source_asset_controller.py
@@ -51,6 +51,8 @@ def fixture_mock_service():
     service.get_all_vto_assets = AsyncMock()
     service.delete_asset = AsyncMock()
     service.get_asset_by_id = AsyncMock()
+    service.generate_signed_upload_url = AsyncMock()
+    service.finalize_direct_upload = AsyncMock()
     return service
 
 
@@ -263,3 +265,95 @@ def test_get_source_asset_not_found(client, mock_service):
     mock_service.get_asset_by_id.return_value = None
     response = client.get("/api/source_assets/999")
     assert response.status_code == 404
+
+
+def test_generate_source_asset_upload_url_success(
+    client, mock_service, mock_workspace_auth
+):
+    from src.source_assets.dto.generate_upload_url_dto import (
+        GenerateSourceAssetUploadUrlResponseDto,
+    )
+
+    mock_service.generate_signed_upload_url.return_value = (
+        GenerateSourceAssetUploadUrlResponseDto(
+            upload_url="https://signed.gcs/upload",
+            gcs_uri="gs://b/source_assets/1/uploads/uuid/test.png",
+            file_uuid="uuid-123",
+        )
+    )
+
+    payload = {
+        "workspaceId": 1,
+        "filename": "test.png",
+        "contentType": "image/png",
+        "size": 1024,
+    }
+    response = client.post(
+        "/api/source_assets/generate-upload-url", json=payload
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["uploadUrl"] == "https://signed.gcs/upload"
+    assert data["gcsUri"] == "gs://b/source_assets/1/uploads/uuid/test.png"
+    assert data["fileUuid"] == "uuid-123"
+    mock_workspace_auth.authorize.assert_called_once()
+
+
+def test_generate_source_asset_upload_url_too_large(client):
+    payload = {
+        "workspaceId": 1,
+        "filename": "huge.mp4",
+        "contentType": "video/mp4",
+        "size": 600 * 1024 * 1024,
+    }
+    response = client.post(
+        "/api/source_assets/generate-upload-url", json=payload
+    )
+    assert response.status_code == 413
+
+
+def test_generate_source_asset_upload_url_invalid_format(client):
+    payload = {
+        "workspaceId": 1,
+        "filename": "document.pdf",
+        "contentType": "application/pdf",
+        "size": 1024,
+    }
+    response = client.post(
+        "/api/source_assets/generate-upload-url", json=payload
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported file format."
+
+
+def test_finalize_source_asset_upload_success(
+    client, mock_service, mock_workspace_auth, mock_user
+):
+    mock_response = SourceAssetResponseDto(
+        id=10,
+        workspace_id=1,
+        user_id=mock_user.id,
+        gcs_uri="gs://b/source_assets/1/uploads/uuid/test.png",
+        original_filename="test.png",
+        mime_type=MimeTypeEnum.IMAGE_PNG,
+        aspect_ratio="1:1",
+        file_hash="hash123",
+        scope=AssetScopeEnum.PRIVATE,
+        asset_type=AssetTypeEnum.GENERIC_IMAGE,
+        presigned_url="https://signed.url",
+        presigned_original_url="",
+        presigned_thumbnail_url="",
+        user_email=mock_user.email,
+    )
+    mock_service.finalize_direct_upload.return_value = mock_response
+
+    payload = {
+        "workspaceId": 1,
+        "gcsUri": "gs://b/source_assets/1/uploads/uuid/test.png",
+        "filename": "test.png",
+        "mimeType": "image/png",
+        "size": 1024,
+    }
+    response = client.post("/api/source_assets/finalize-upload", json=payload)
+    assert response.status_code == 201
+    assert response.json()["id"] == 10

--- a/backend/tests/source_assets/test_source_asset_service.py
+++ b/backend/tests/source_assets/test_source_asset_service.py
@@ -601,3 +601,173 @@ async def test_upload_asset_upscale_failure(
     )
 
     assert response.id == 80
+
+
+@pytest.mark.anyio
+async def test_generate_signed_upload_url_success(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.generate_upload_url_dto import (
+        GenerateSourceAssetUploadUrlDto,
+    )
+
+    mock_dependencies[
+        "iam_signer"
+    ].generate_v4_upload_signed_url.return_value = (
+        "https://signed.gcs/upload",
+        "gs://bucket/source_assets/1/uploads/uuid/test.png",
+    )
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
+
+    dto = GenerateSourceAssetUploadUrlDto(
+        workspace_id=1,
+        filename="test.png",
+        content_type="image/png",
+        size=1024,
+    )
+    result = await service.generate_signed_upload_url(dto, sample_user)
+
+    assert result.upload_url == "https://signed.gcs/upload"
+    assert result.gcs_uri == "gs://bucket/source_assets/1/uploads/uuid/test.png"
+    assert result.file_uuid is not None
+
+
+@pytest.mark.anyio
+async def test_generate_signed_upload_url_error(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.generate_upload_url_dto import (
+        GenerateSourceAssetUploadUrlDto,
+    )
+
+    mock_dependencies[
+        "iam_signer"
+    ].generate_v4_upload_signed_url.return_value = (
+        None,
+        None,
+    )
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
+
+    dto = GenerateSourceAssetUploadUrlDto(
+        workspace_id=1,
+        filename="test.png",
+        content_type="image/png",
+        size=1024,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await service.generate_signed_upload_url(dto, sample_user)
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.anyio
+async def test_finalize_direct_upload_success_image(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.finalize_upload_dto import (
+        FinalizeSourceAssetUploadDto,
+    )
+
+    mock_dependencies["iam_signer"].generate_presigned_url.return_value = (
+        "https://signed.url"
+    )
+
+    saved_asset = SourceAssetModel(
+        id=101,
+        workspace_id=1,
+        user_id=sample_user.id,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/image.png",
+        original_filename="image.png",
+        file_hash="hash101",
+        mime_type=MimeTypeEnum.IMAGE_PNG,
+    )
+    mock_dependencies["repo"].create.return_value = saved_asset
+
+    dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/image.png",
+        filename="image.png",
+        mime_type="image/png",
+        size=2048,
+    )
+    response = await service.finalize_direct_upload(dto, sample_user)
+
+    assert response.id == 101
+    assert response.original_filename == "image.png"
+    mock_dependencies["repo"].create.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_finalize_direct_upload_video_and_audio(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.finalize_upload_dto import (
+        FinalizeSourceAssetUploadDto,
+    )
+
+    mock_dependencies["iam_signer"].generate_presigned_url.return_value = (
+        "https://signed.url"
+    )
+
+    saved_video = SourceAssetModel(
+        id=102,
+        workspace_id=1,
+        user_id=sample_user.id,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/video.mp4",
+        original_filename="video.mp4",
+        file_hash="hash102",
+        mime_type=MimeTypeEnum.VIDEO_MP4,
+        asset_type=AssetTypeEnum.GENERIC_VIDEO,
+    )
+    mock_dependencies["repo"].create.return_value = saved_video
+
+    video_dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/video.mp4",
+        filename="video.mp4",
+        mime_type="video/mp4",
+        size=50000,
+    )
+    res_video = await service.finalize_direct_upload(video_dto, sample_user)
+    assert res_video.id == 102
+
+    saved_audio = SourceAssetModel(
+        id=103,
+        workspace_id=1,
+        user_id=sample_user.id,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/audio.mp3",
+        original_filename="audio.mp3",
+        file_hash="hash103",
+        mime_type=MimeTypeEnum.AUDIO_MPEG,
+    )
+    mock_dependencies["repo"].create.return_value = saved_audio
+
+    audio_dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/audio.mp3",
+        filename="audio.mp3",
+        mime_type="audio/mp3",
+        size=30000,
+    )
+    res_audio = await service.finalize_direct_upload(audio_dto, sample_user)
+    assert res_audio.id == 103
+
+
+@pytest.mark.anyio
+async def test_finalize_direct_upload_non_admin_scope_error(
+    service, sample_user
+):
+    from src.source_assets.dto.finalize_upload_dto import (
+        FinalizeSourceAssetUploadDto,
+    )
+
+    dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://b/file.png",
+        filename="file.png",
+        mime_type="image/png",
+        size=100,
+        scope=AssetScopeEnum.SYSTEM,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await service.finalize_direct_upload(dto, sample_user)
+    assert exc_info.value.status_code == 403

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -53,3 +53,4 @@
     </div>
   </div>
 </div>
+<app-upload-progress-widget/>

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
+import {of} from 'rxjs';
 import {AppComponent} from './app.component';
 import {LoadingService} from './common/services/loading.service';
-import {of} from 'rxjs';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {MediaUploadService} from './common/services/media-upload/media-upload.service';
 
 describe('AppComponent', () => {
-  let loadingServiceMock: any;
+  let loadingServiceMock: unknown;
 
   beforeEach(async () => {
     loadingServiceMock = {
@@ -30,9 +32,12 @@ describe('AppComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, HttpClientTestingModule],
       declarations: [AppComponent],
-      providers: [{provide: LoadingService, useValue: loadingServiceMock}],
+      providers: [
+        {provide: LoadingService, useValue: loadingServiceMock},
+        MediaUploadService,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -18,6 +18,7 @@ import {Component} from '@angular/core';
 import {Router, NavigationEnd, Event as NavigationEvent} from '@angular/router';
 import {trigger, transition, style, query, animate} from '@angular/animations';
 import {LoadingService} from './common/services/loading.service';
+import {MediaUploadService} from './common/services/media-upload/media-upload.service';
 
 @Component({
   selector: 'app-root',
@@ -57,6 +58,7 @@ export class AppComponent {
   constructor(
     private router: Router,
     public loadingService: LoadingService,
+    public uploadService: MediaUploadService,
   ) {
     this.router.events.subscribe((event: NavigationEvent) => {
       if (event instanceof NavigationEnd) {

--- a/frontend/src/app/common/components/studio-button/studio-button.component.html
+++ b/frontend/src/app/common/components/studio-button/studio-button.component.html
@@ -18,7 +18,7 @@
   mat-flat-button
   [ngClass]="classes"
   [disabled]="disabled"
+  (click)="handleHostClick($event)"
 >
-
   <ng-content></ng-content>
 </button>

--- a/frontend/src/app/common/components/studio-button/studio-button.component.ts
+++ b/frontend/src/app/common/components/studio-button/studio-button.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Component, Input} from '@angular/core';
+import {Component, HostBinding, Input} from '@angular/core';
 
 @Component({
   selector: 'studio-button',
@@ -45,5 +45,19 @@ export class StudioButtonComponent {
     }
 
     return classList.join(' ');
+  }
+
+  @HostBinding('style.pointer-events')
+  get pointerEvents(): string {
+    return this.disabled ? 'none' : 'auto';
+  }
+
+  handleHostClick(event: MouseEvent): void {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      return;
+    }
   }
 }

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
@@ -1,0 +1,257 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div
+  *ngIf="!isLoginRoute() && uploadService.hasActiveOrFinishedUploads()"
+  id="upload-progress-widget"
+  class="upload-widget-container"
+  [class.minimized]="!isExpanded()"
+>
+  <div
+    *ngIf="!isExpanded()"
+    id="upload-widget-minimized"
+    class="minimized-pill"
+  >
+    <ng-container *ngTemplateOutlet="uploadWidgetHeader"></ng-container>
+  </div>
+
+  <!-- MAXIMIZED DETAILED PANEL MODE -->
+  <div
+    *ngIf="isExpanded()"
+    id="upload-widget-maximized"
+    class="maximized-panel"
+  >
+    <!-- HEADER -->
+    <div class="panel-header">
+      <ng-container *ngTemplateOutlet="uploadWidgetHeader"></ng-container>
+    </div>
+
+    <!-- OVERALL PROGRESS BAR -->
+    <div
+      *ngIf="uploadService.inProgressCount() > 0"
+      class="overall-progress-track"
+    >
+      <div
+        class="overall-progress-fill"
+        [style.width.%]="uploadService.overallProgress()"
+      ></div>
+    </div>
+
+    <!-- FILE LIST -->
+    <div id="upload-widget-file-list" class="file-list">
+      <div
+        *ngFor="let item of uploadService.uploadQueue()"
+        [id]="'upload-item-' + item.id"
+        class="file-item-row"
+        [class.item-failed]="item.status === UploadStatus.FAILED"
+        [class.item-completed]="item.status === UploadStatus.COMPLETED"
+        [class.item-cancelled]="item.status === UploadStatus.CANCELLED"
+      >
+        <!-- FILE ICON & RETRY/CANCEL ACTION -->
+        <div class="item-icon-wrapper">
+          <mat-icon class="file-type-icon">{{
+            getFileIcon(item.mimeType)
+          }}</mat-icon>
+          <button
+            *ngIf="item.status === UploadStatus.FAILED || item.status === UploadStatus.CANCELLED"
+            [id]="'retry-btn-' + item.id"
+            class="retry-item-btn"
+            type="button"
+            title="Retry uploading file"
+            (click)="onRetryItem(item.id)"
+          >
+            <mat-icon>refresh</mat-icon>
+          </button>
+          <button
+            *ngIf="
+              item.status === UploadStatus.QUEUED ||
+              item.status === UploadStatus.GENERATING_URL ||
+              item.status === UploadStatus.UPLOADING ||
+              item.status === UploadStatus.FINALIZING
+            "
+            [id]="'cancel-btn-' + item.id"
+            class="cancel-item-btn"
+            type="button"
+            title="Cancel upload"
+            (click)="onCancelItem(item.id)"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+
+        <!-- DETAILS -->
+        <div class="item-details">
+          <div class="item-meta">
+            <span class="item-filename" [title]="item.filename">{{
+              item.filename
+            }}</span>
+            <span class="item-size">{{ formatFileSize(item.size) }}</span>
+          </div>
+
+          <!-- STATUS SPECIFIC RENDERING -->
+          <div class="item-status-container">
+            <!-- QUEUED -->
+            <div
+              *ngIf="item.status === UploadStatus.QUEUED"
+              class="status-badge status-queued"
+            >
+              <mat-icon class="badge-icon">schedule</mat-icon>
+              <span>Waiting in queue (Max 5 concurrent)</span>
+            </div>
+
+            <!-- GENERATING URL -->
+            <div
+              *ngIf="item.status === UploadStatus.GENERATING_URL"
+              class="status-badge status-preparing"
+            >
+              <mat-spinner diameter="14" strokeWidth="2"></mat-spinner>
+              <span>Preparing signed URL</span>
+            </div>
+
+            <!-- UPLOADING -->
+            <div
+              *ngIf="item.status === UploadStatus.UPLOADING"
+              class="status-uploading"
+            >
+              <div class="progress-bar-track">
+                <div
+                  class="progress-bar-fill"
+                  [style.width.%]="item.progress"
+                ></div>
+              </div>
+              <span class="progress-pct-text">{{ item.progress }}%</span>
+            </div>
+
+            <!-- FINALIZING -->
+            <div
+              *ngIf="item.status === UploadStatus.FINALIZING"
+              class="status-badge status-finalizing"
+            >
+              <mat-spinner diameter="14" strokeWidth="2"></mat-spinner>
+              <span>Finalizing asset</span>
+            </div>
+
+            <!-- COMPLETED -->
+            <div
+              *ngIf="item.status === UploadStatus.COMPLETED"
+              class="status-badge status-completed"
+            >
+              <mat-icon class="badge-icon">check_circle</mat-icon>
+              <span>Uploaded successfully</span>
+            </div>
+
+            <!-- FAILED -->
+            <div
+              *ngIf="item.status === UploadStatus.FAILED"
+              class="status-badge status-failed"
+            >
+              <mat-icon class="badge-icon">error</mat-icon>
+              <span class="error-msg">{{
+                item.errorMessage || 'Upload failed'
+              }}</span>
+            </div>
+
+            <!-- CANCELLED -->
+            <div
+              *ngIf="item.status === UploadStatus.CANCELLED"
+              class="status-badge status-cancelled"
+            >
+              <mat-icon class="badge-icon">cancel</mat-icon>
+              <span>Upload cancelled</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- FOOTER ACTION FOR ALL FAILED -->
+    <div class="panel-footer">
+      <button
+        id="retry-all-failed-btn"
+        class="retry-all-btn"
+        type="button"
+        [disabled]="uploadService.totalFailed() === 0 || !uploadService.canClose()"
+        (click)="onRetryAll()"
+      >
+        <mat-icon>refresh</mat-icon>
+        <span>Retry All Failed</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<ng-template #uploadWidgetHeader>
+  <div class="pill-left">
+    <span class="pill-title"
+      >Uploads: {{ uploadService.overallProgress() }}%</span
+    >
+  </div>
+
+  <div class="pill-badges">
+    <span
+      *ngIf="uploadService.totalUploaded() > 0"
+      class="indicator-item indicator-success"
+      [attr.title]="'Successful uploads: ' + uploadService.totalUploaded()"
+    >
+      <mat-icon class="indicator-icon">check_circle</mat-icon>
+      <span>{{ uploadService.totalUploaded() }}</span>
+    </span>
+    <span
+      *ngIf="uploadService.totalFailed() > 0"
+      class="indicator-item indicator-error"
+      [attr.title]="'Failed uploads: ' + uploadService.totalFailed()"
+    >
+      <mat-icon class="indicator-icon">warning</mat-icon>
+      <span>{{ uploadService.totalFailed() }}</span>
+    </span>
+    <span
+      *ngIf="uploadService.totalCancelled() > 0"
+      class="indicator-item indicator-cancelled"
+      [attr.title]="'Cancelled uploads: ' + uploadService.totalCancelled()"
+    >
+      <mat-icon class="indicator-icon">cancel</mat-icon>
+      <span>{{ uploadService.totalCancelled() }}</span>
+    </span>
+  </div>
+
+  <div class="pill-actions">
+    <button
+      id="upload-widget-expand-btn"
+      class="icon-btn"
+      type="button"
+      [title]="
+        isExpanded() ? 'Minimize panel' : 'Expand upload progress panel'
+      "
+      (click)="toggleExpand()"
+    >
+      <mat-icon>{{ isExpanded() ? 'expand_more' : 'expand_less' }}</mat-icon>
+    </button>
+    <button
+      id="upload-widget-min-close-btn"
+      class="icon-btn close-btn"
+      type="button"
+      [disabled]="!uploadService.canClose()"
+      [attr.title]="
+        uploadService.canClose()
+          ? 'Clear upload list'
+          : 'Uploads in progress'
+      "
+      (click)="onClose()"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+</ng-template>

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
@@ -1,0 +1,472 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.upload-widget-container {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 2000;
+  color: #f1f5f9;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* MINIMIZED PILL MODE */
+  .minimized-pill {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: rgba(20, 24, 33, 0.92);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 9999px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5), 0 0 1px rgba(255, 255, 255, 0.2);
+
+    &:hover {
+      background: rgba(28, 34, 46, 0.95);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    .pill-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      .pill-title {
+        font-weight: 500;
+        font-size: 13px;
+        color: #e2e8f0;
+      }
+    }
+
+    .pill-badges {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .pill-actions {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+  }
+
+  /* MAXIMIZED DETAILED PANEL MODE */
+  .maximized-panel {
+    width: 380px;
+    max-width: calc(100vw - 32px);
+    background: rgba(18, 22, 31, 0.94);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 16px;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.6), 0 0 2px rgba(255, 255, 255, 0.25);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 16px;
+      background: rgba(255, 255, 255, 0.03);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+      .header-title,
+      .pill-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        font-size: 14px;
+        color: #f8fafc;
+
+        .pill-title {
+          font-weight: 600;
+          font-size: 14px;
+          color: #f8fafc;
+        }
+
+        .header-icon {
+          color: #00e5ff;
+          font-size: 20px;
+          width: 20px;
+          height: 20px;
+        }
+
+        .progress-badge {
+          font-size: 11px;
+          font-weight: 700;
+          color: #00e5ff;
+          background: rgba(0, 229, 255, 0.12);
+          padding: 2px 8px;
+          border-radius: 12px;
+          border: none;
+        }
+      }
+
+      .header-badges,
+      .pill-badges {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .header-actions,
+      .pill-actions {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+    }
+
+    .overall-progress-track {
+      height: 3px;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.08);
+
+      .overall-progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #00e5ff 0%, #00e676 100%);
+        transition: width 0.3s ease-out;
+      }
+    }
+
+    .file-list {
+      max-height: 260px;
+      overflow-y: auto;
+      padding: 4px 12px;
+      display: flex;
+      flex-direction: column;
+
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+      &::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 3px;
+      }
+
+      .file-item-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 10px 4px;
+        background: transparent;
+        border: none;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        transition: background 0.2s ease;
+
+        &.item-cancelled {
+          background: rgba(255, 255, 255, 0.01);
+        }
+
+        &:last-child {
+          border-bottom: none;
+        }
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.03);
+        }
+
+        .item-icon-wrapper {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 6px;
+          padding-top: 2px;
+          min-width: 24px;
+
+          .file-type-icon {
+            color: #94a3b8;
+            font-size: 20px;
+            width: 20px;
+            height: 20px;
+          }
+
+          .retry-item-btn {
+            background: rgba(255, 82, 82, 0.15);
+            color: #ff5252;
+            border: 1px solid rgba(255, 82, 82, 0.3);
+            border-radius: 4px;
+            padding: 2px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s ease;
+
+            &:hover {
+              background: rgba(255, 82, 82, 0.3);
+              color: #ffffff;
+            }
+
+            mat-icon {
+              font-size: 14px;
+              width: 14px;
+              height: 14px;
+            }
+          }
+
+          .cancel-item-btn {
+            background: rgba(255, 255, 255, 0.08);
+            color: #94a3b8;
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 4px;
+            padding: 2px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s ease;
+
+            &:hover {
+              background: rgba(239, 68, 68, 0.15);
+              color: #ef4444;
+              border-color: rgba(239, 68, 68, 0.3);
+            }
+
+            mat-icon {
+              font-size: 14px;
+              width: 14px;
+              height: 14px;
+            }
+          }
+        }
+
+        .item-details {
+          flex: 1;
+          min-width: 0;
+
+          .item-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 4px;
+
+            .item-filename {
+              font-weight: 500;
+              font-size: 13px;
+              color: #f1f5f9;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            }
+
+            .item-size {
+              font-size: 11px;
+              color: #64748b;
+              white-space: nowrap;
+            }
+          }
+
+          .item-status-container {
+            font-size: 11px;
+
+            .status-badge {
+              display: flex;
+              align-items: center;
+              gap: 4px;
+              max-width: 100%;
+              white-space: nowrap;
+              overflow: hidden;
+
+              span {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .badge-icon {
+                font-size: 14px;
+                width: 14px;
+                height: 14px;
+                flex-shrink: 0;
+              }
+
+              &.status-queued {
+                color: #ffb300;
+              }
+
+              &.status-preparing {
+                color: #38bdf8;
+              }
+
+              &.status-finalizing {
+                color: #a855f7;
+              }
+
+              &.status-completed {
+                color: #00e676;
+              }
+
+              &.status-failed {
+                color: #ff5252;
+                .error-msg {
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                }
+              }
+
+              &.status-cancelled {
+                color: #94a3b8;
+              }
+            }
+
+            .status-uploading {
+              display: flex;
+              align-items: center;
+              gap: 8px;
+
+              .progress-bar-track {
+                flex: 1;
+                height: 4px;
+                background: rgba(255, 255, 255, 0.1);
+                border-radius: 2px;
+                overflow: hidden;
+
+                .progress-bar-fill {
+                  height: 100%;
+                  background: #00e5ff;
+                  transition: width 0.2s ease-out;
+                }
+              }
+
+              .progress-pct-text {
+                font-weight: 600;
+                color: #00e5ff;
+                font-size: 11px;
+                min-width: 32px;
+                text-align: right;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    .panel-footer {
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.02);
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      justify-content: flex-end;
+
+      .retry-all-btn {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+        color: #ffffff;
+        border: none;
+        padding: 6px 12px;
+        border-radius: 8px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+        transition: all 0.2s ease;
+
+        &:hover {
+          background: linear-gradient(135deg, #f87171 0%, #ef4444 100%);
+          box-shadow: 0 6px 16px rgba(239, 68, 68, 0.45);
+        }
+
+        &:disabled {
+          background: rgba(255, 255, 255, 0.08);
+          color: rgba(255, 255, 255, 0.35);
+          box-shadow: none;
+          pointer-events: none;
+        }
+
+        mat-icon {
+          font-size: 16px;
+          width: 16px;
+          height: 16px;
+        }
+      }
+    }
+  }
+
+  /* BORDERLESS NON-BUTTON STATE INDICATORS */
+  .indicator-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 6px;
+    border: none;
+
+    .indicator-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &.indicator-success {
+      color: #00e676;
+      background: rgba(0, 230, 118, 0.12);
+    }
+
+    &.indicator-error {
+      color: #ff5252;
+      background: rgba(255, 82, 82, 0.12);
+    }
+
+    &.indicator-cancelled {
+      color: #94a3b8;
+      background: rgba(148, 163, 184, 0.12);
+    }
+  }
+
+  .icon-btn {
+    background: transparent;
+    border: none;
+    color: #94a3b8;
+    border-radius: 6px;
+    padding: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+
+    &:hover {
+      color: #f8fafc;
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &.close-btn {
+      &:disabled,
+      &.disabled {
+        opacity: 0.35;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.spec.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Router} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {UploadProgressWidgetComponent} from './upload-progress-widget.component';
+import {
+  MediaUploadService,
+  UploadItem,
+  UploadStatus,
+} from '../../services/media-upload/media-upload.service';
+import {WorkspaceStateService} from '../../../services/workspace/workspace-state.service';
+import {UserService} from '../../services/user.service';
+
+describe('UploadProgressWidgetComponent', () => {
+  let component: UploadProgressWidgetComponent;
+  let fixture: ComponentFixture<UploadProgressWidgetComponent>;
+  let uploadService: MediaUploadService;
+  let workspaceService: WorkspaceStateService;
+  let router: Router;
+  let mockUserService: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    mockUserService = jasmine.createSpyObj('UserService', ['getUserDetails']);
+    mockUserService.getUserDetails.and.returnValue({
+      email: 'test@google.com',
+      name: 'Test User',
+      picture: '',
+      roles: [],
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MatIconModule,
+        MatProgressSpinnerModule,
+      ],
+      declarations: [UploadProgressWidgetComponent],
+      providers: [
+        MediaUploadService,
+        WorkspaceStateService,
+        {provide: UserService, useValue: mockUserService},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UploadProgressWidgetComponent);
+    component = fixture.componentInstance;
+    uploadService = TestBed.inject(MediaUploadService);
+    workspaceService = TestBed.inject(WorkspaceStateService);
+    router = TestBed.inject(Router);
+    workspaceService.setActiveWorkspaceId(123);
+    fixture.detectChanges();
+  });
+
+  it('should create component', () => {
+    expect(component).toBeTruthy();
+    expect(component.isExpanded()).toBeTrue();
+  });
+
+  it('should detect login route correctly', () => {
+    spyOnProperty(router, 'url', 'get').and.returnValue('/login');
+    expect(component.isLoginRoute()).toBeTrue();
+
+    (
+      Object.getOwnPropertyDescriptor(router, 'url')?.get as jasmine.Spy
+    ).and.returnValue('/gallery');
+    expect(component.isLoginRoute()).toBeFalse();
+  });
+
+  it('should toggle expanded and minimized states', () => {
+    expect(component.isExpanded()).toBeTrue();
+    component.toggleExpand();
+    expect(component.isExpanded()).toBeFalse();
+    component.toggleExpand();
+    expect(component.isExpanded()).toBeTrue();
+  });
+
+  it('should format file icons correctly based on mimeType', () => {
+    expect(component.getFileIcon('image/jpeg')).toBe('image');
+    expect(component.getFileIcon('video/mp4')).toBe('videocam');
+    expect(component.getFileIcon('audio/wav')).toBe('audiotrack');
+    expect(component.getFileIcon('application/pdf')).toBe('insert_drive_file');
+    expect(component.getFileIcon('')).toBe('insert_drive_file');
+  });
+
+  it('should format file sizes cleanly', () => {
+    expect(component.formatFileSize(0)).toBe('0 B');
+    expect(component.formatFileSize(512)).toBe('512 B');
+    expect(component.formatFileSize(1024 * 500)).toBe('500 KB');
+    expect(component.formatFileSize(1024 * 1024 * 14.2)).toBe('14.2 MB');
+  });
+
+  it('should disable close button when uploads are in progress', () => {
+    const itemInFlight: UploadItem = {
+      id: 'item-1',
+      filename: 'test.png',
+      size: 1024,
+      mimeType: 'image/png',
+      status: UploadStatus.UPLOADING,
+      progress: 40,
+    };
+
+    uploadService.uploadQueue.set([itemInFlight]);
+    fixture.detectChanges();
+
+    expect(uploadService.canClose()).toBeFalse();
+
+    component.onClose();
+    // Queue should remain intact because clearQueue is guarded by canClose
+    expect(uploadService.uploadQueue().length).toBe(1);
+  });
+
+  it('should enable close button and clear queue when transfers reach terminal state', () => {
+    const completedItem: UploadItem = {
+      id: 'item-1',
+      filename: 'done.png',
+      size: 1024,
+      mimeType: 'image/png',
+      status: UploadStatus.COMPLETED,
+      progress: 100,
+    };
+
+    uploadService.uploadQueue.set([completedItem]);
+    fixture.detectChanges();
+
+    expect(uploadService.canClose()).toBeTrue();
+
+    component.onClose();
+    expect(uploadService.uploadQueue().length).toBe(0);
+  });
+
+  it('should invoke retryUpload when item retry action is triggered', () => {
+    spyOn(uploadService, 'retryUpload');
+
+    const failedItem: UploadItem = {
+      id: 'item-fail',
+      filename: 'error.png',
+      size: 1024,
+      mimeType: 'image/png',
+      status: UploadStatus.FAILED,
+      progress: 0,
+      errorMessage: 'Network timeout',
+    };
+
+    uploadService.uploadQueue.set([failedItem]);
+    fixture.detectChanges();
+
+    component.onRetryItem('item-fail');
+    expect(uploadService.retryUpload).toHaveBeenCalledWith(123, 'item-fail');
+  });
+
+  it('should invoke retryAllFailed when retry all button is clicked', () => {
+    spyOn(uploadService, 'retryAllFailed');
+
+    const failedItems: UploadItem[] = [
+      {
+        id: 'f1',
+        filename: 'f1.png',
+        size: 100,
+        mimeType: 'image/png',
+        status: UploadStatus.FAILED,
+        progress: 0,
+      },
+      {
+        id: 'f2',
+        filename: 'f2.png',
+        size: 200,
+        mimeType: 'image/png',
+        status: UploadStatus.FAILED,
+        progress: 0,
+      },
+    ];
+
+    uploadService.uploadQueue.set(failedItems);
+    fixture.detectChanges();
+
+    component.onRetryAll();
+    expect(uploadService.retryAllFailed).toHaveBeenCalledWith(123);
+  });
+
+  it('should render shared header template in expanded and minimized states', () => {
+    uploadService.uploadQueue.set([
+      {
+        id: '1',
+        filename: 'file.png',
+        size: 100,
+        mimeType: 'image/png',
+        status: UploadStatus.COMPLETED,
+        progress: 100,
+      },
+    ]);
+    fixture.detectChanges();
+
+    // Expanded mode
+    expect(component.isExpanded()).toBeTrue();
+    const expandedHeader = fixture.nativeElement.querySelector('.panel-header');
+    expect(expandedHeader).toBeTruthy();
+    expect(expandedHeader.querySelector('.pill-title')?.textContent).toContain(
+      'Uploads:',
+    );
+
+    // Minimized mode
+    component.toggleExpand();
+    fixture.detectChanges();
+    expect(component.isExpanded()).toBeFalse();
+    const minimizedPill =
+      fixture.nativeElement.querySelector('.minimized-pill');
+    expect(minimizedPill).toBeTruthy();
+    expect(minimizedPill.querySelector('.pill-title')?.textContent).toContain(
+      'Uploads:',
+    );
+  });
+
+  it('should render cancel button for uncompleted uploads and invoke cancelUpload on click', () => {
+    spyOn(uploadService, 'cancelUpload');
+
+    uploadService.uploadQueue.set([
+      {
+        id: 'item-queued',
+        filename: 'queued.png',
+        size: 100,
+        mimeType: 'image/png',
+        status: UploadStatus.QUEUED,
+        progress: 0,
+      },
+      {
+        id: 'item-completed',
+        filename: 'done.png',
+        size: 200,
+        mimeType: 'image/png',
+        status: UploadStatus.COMPLETED,
+        progress: 100,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const queuedRow = fixture.nativeElement.querySelector(
+      '#upload-item-item-queued',
+    );
+    const completedRow = fixture.nativeElement.querySelector(
+      '#upload-item-item-completed',
+    );
+
+    expect(queuedRow).toBeTruthy();
+    expect(completedRow).toBeTruthy();
+
+    const queuedCancelBtn = queuedRow.querySelector('#cancel-btn-item-queued');
+    const completedCancelBtn = completedRow.querySelector(
+      '#cancel-btn-item-completed',
+    );
+
+    expect(queuedCancelBtn).toBeTruthy();
+    expect(completedCancelBtn).toBeNull();
+
+    queuedCancelBtn.click();
+    fixture.detectChanges();
+
+    expect(uploadService.cancelUpload).toHaveBeenCalledWith('item-queued');
+  });
+
+  it('should display cancelled indicators in header when there are cancelled items', () => {
+    uploadService.uploadQueue.set([
+      {
+        id: 'item-cancelled',
+        filename: 'cancelled.png',
+        size: 300,
+        mimeType: 'image/png',
+        status: UploadStatus.CANCELLED,
+        progress: 0,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const cancelledIndicator = fixture.nativeElement.querySelector(
+      '.indicator-cancelled',
+    );
+    expect(cancelledIndicator).toBeTruthy();
+    expect(cancelledIndicator.textContent).toContain('1');
+  });
+});

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, signal} from '@angular/core';
+import {Router} from '@angular/router';
+import {
+  MediaUploadService,
+  UploadStatus,
+} from '../../services/media-upload/media-upload.service';
+import {WorkspaceStateService} from '../../../services/workspace/workspace-state.service';
+
+@Component({
+  selector: 'app-upload-progress-widget',
+  templateUrl: './upload-progress-widget.component.html',
+  styleUrls: ['./upload-progress-widget.component.scss'],
+})
+export class UploadProgressWidgetComponent {
+  readonly isExpanded = signal<boolean>(true);
+  readonly UploadStatus = UploadStatus;
+
+  constructor(
+    public uploadService: MediaUploadService,
+    private workspaceStateService: WorkspaceStateService,
+    private router: Router,
+  ) {}
+
+  isLoginRoute(): boolean {
+    return this.router.url.startsWith('/login');
+  }
+
+  toggleExpand(): void {
+    this.isExpanded.update(val => !val);
+  }
+
+  onClose(): void {
+    if (this.uploadService.canClose()) {
+      this.uploadService.clearQueue();
+    }
+  }
+
+  onCancelItem(itemId: string): void {
+    this.uploadService.cancelUpload(itemId);
+  }
+
+  onRetryItem(itemId: string): void {
+    const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+    if (workspaceId !== null) {
+      this.uploadService.retryUpload(workspaceId, itemId);
+    }
+  }
+
+  onRetryAll(): void {
+    const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+    if (workspaceId !== null) {
+      this.uploadService.retryAllFailed(workspaceId);
+    }
+  }
+
+  getFileIcon(mimeType: string): string {
+    if (!mimeType) return 'insert_drive_file';
+    if (mimeType.startsWith('image/')) return 'image';
+    if (mimeType.startsWith('video/')) return 'videocam';
+    if (mimeType.startsWith('audio/')) return 'audiotrack';
+    return 'insert_drive_file';
+  }
+
+  formatFileSize(bytes: number): string {
+    if (!bytes || bytes <= 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+  }
+}

--- a/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
@@ -1,0 +1,717 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import {TestBed} from '@angular/core/testing';
+import {HttpEventType, HttpResponse} from '@angular/common/http';
+import {Event, NavigationEnd, Router} from '@angular/router';
+import {Subject} from 'rxjs';
+import {environment} from '../../../../environments/environment';
+import {
+  MediaUploadService,
+  UploadItem,
+  UploadStatus,
+} from './media-upload.service';
+import {UserService} from '../user.service';
+
+const MOCK_SESSION_STORAGE_UPLOAD_KEY =
+  'cs_media_uploads_active_job_test@google.com';
+
+describe('MediaUploadService', () => {
+  let service: MediaUploadService;
+  let httpMock: HttpTestingController;
+  let mockUserService: jasmine.SpyObj<UserService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let routerEventsSubject: Subject<Event>;
+
+  const mockWorkspaceId = 123;
+  const apiUrl = `${environment.backendURL}/source_assets`;
+
+  function createDummyFile(
+    name: string,
+    type = 'image/png',
+    size = 1024,
+  ): File {
+    const blob = new Blob(['a'.repeat(size)], {type});
+    return new File([blob], name, {type});
+  }
+
+  beforeEach(() => {
+    sessionStorage.removeItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+
+    mockUserService = jasmine.createSpyObj('UserService', ['getUserDetails']);
+    mockUserService.getUserDetails.and.returnValue({
+      email: 'test@google.com',
+      name: 'Test User',
+      picture: '',
+      roles: [],
+    });
+
+    routerEventsSubject = new Subject<Event>();
+    mockRouter = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
+    (mockRouter as any).events = routerEventsSubject.asObservable();
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        MediaUploadService,
+        {provide: UserService, useValue: mockUserService},
+        {provide: Router, useValue: mockRouter},
+      ],
+    });
+
+    service = TestBed.inject(MediaUploadService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sessionStorage.removeItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+  });
+
+  it('should be created with initial empty state', () => {
+    expect(service).toBeTruthy();
+    expect(service.uploadQueue()).toEqual([]);
+    expect(service.totalCount()).toBe(0);
+    expect(service.totalUploaded()).toBe(0);
+    expect(service.totalFailed()).toBe(0);
+    expect(service.inProgressCount()).toBe(0);
+    expect(service.queuedCount()).toBe(0);
+    expect(service.overallProgress()).toBe(0);
+    expect(service.canClose()).toBeTrue();
+    expect(service.hasActiveOrFinishedUploads()).toBeFalse();
+  });
+
+  it('should validate allowed file types correctly', () => {
+    const pngFile = createDummyFile('test.png', 'image/png');
+    const mp4File = createDummyFile('test.mp4', 'video/mp4');
+    const wavFile = createDummyFile('test.wav', 'audio/wav');
+    const pdfFile = createDummyFile('test.pdf', 'application/pdf');
+
+    expect(service.isAllowedFileType(pngFile)).toBeTrue();
+    expect(service.isAllowedFileType(mp4File)).toBeTrue();
+    expect(service.isAllowedFileType(wavFile)).toBeTrue();
+    expect(service.isAllowedFileType(pdfFile)).toBeFalse();
+  });
+
+  it('should mark unsupported file formats as FAILED immediately', () => {
+    const pdfFile = createDummyFile('invalid.pdf', 'application/pdf');
+    service.uploadFiles(mockWorkspaceId, [pdfFile]);
+
+    expect(service.totalCount()).toBe(1);
+    expect(service.totalFailed()).toBe(1);
+    expect(service.uploadQueue()[0].errorMessage).toContain(
+      'Unsupported format',
+    );
+  });
+
+  describe('Concurrency & Queue Throttling (Max 5 Concurrent Uploads)', () => {
+    it('should limit active simultaneous uploads to maximum 5 files', () => {
+      const files = Array.from({length: 8}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.totalCount()).toBe(8);
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(3);
+
+      // Verify 5 generate-upload-url requests are created
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(5);
+
+      reqs.forEach((req, idx) => {
+        expect(req.request.body).toEqual({
+          workspaceId: mockWorkspaceId,
+          filename: `file_${idx + 1}.png`,
+          contentType: 'image/png',
+          size: 1024,
+        });
+      });
+    });
+
+    it('should trigger the next queued file as active uploads complete', () => {
+      const files = Array.from({length: 6}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(1);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(5);
+
+      // Complete the first file's signed URL generation, GCS upload, and finalization
+      const firstReq = reqs[0];
+      firstReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-url-1',
+        gcsUri: 'gs://test-bucket/uploads/file_1.png',
+        fileUuid: 'uuid-1',
+      });
+
+      // GCS PUT request
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-url-1',
+      );
+      putReq.flush(null, {status: 200, statusText: 'OK'});
+
+      // Finalize request
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      expect(finalizeReq.request.body).toEqual({
+        workspaceId: mockWorkspaceId,
+        gcsUri: 'gs://test-bucket/uploads/file_1.png',
+        filename: 'file_1.png',
+        mimeType: 'image/png',
+        size: 1024,
+        assetType: 'generic_image',
+      });
+      finalizeReq.flush({id: 1, originalFilename: 'file_1.png'});
+
+      // Upon completion of file 1, file 6 should be picked up automatically
+      expect(service.totalUploaded()).toBe(1);
+      expect(service.queuedCount()).toBe(0);
+
+      const newReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      expect(newReq.request.body.filename).toBe('file_6.png');
+    });
+  });
+
+  describe('Full Upload Flow & Progress Calculation', () => {
+    it('should track upload progress and emit batch completion when done', done => {
+      let batchCompleted = false;
+      service.uploadBatchComplete$.subscribe(() => {
+        batchCompleted = true;
+      });
+
+      const file = createDummyFile('test-video.mp4', 'video/mp4', 2048);
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      // 1. Signed URL request
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-url-vid',
+        gcsUri: 'gs://test-bucket/uploads/test-video.mp4',
+        fileUuid: 'vid-uuid',
+      });
+
+      // 2. GCS PUT upload with progress
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-url-vid',
+      );
+
+      // Emit 50% upload progress event
+      putReq.event({
+        type: HttpEventType.UploadProgress,
+        loaded: 1024,
+        total: 2048,
+      });
+      expect(service.overallProgress()).toBe(50);
+
+      // Complete PUT response
+      putReq.event(new HttpResponse({status: 200}));
+
+      // 3. Finalize upload
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      expect(finalizeReq.request.body.assetType).toBe('generic_video');
+      finalizeReq.flush({id: 2, originalFilename: 'test-video.mp4'});
+
+      expect(service.totalUploaded()).toBe(1);
+      expect(service.overallProgress()).toBe(100);
+      expect(service.isBatchFinished()).toBeTrue();
+      expect(batchCompleted).toBeTrue();
+      done();
+    });
+  });
+
+  describe('Error Handling & Retries', () => {
+    it('should mark item as FAILED when generate signed URL errors', () => {
+      const file = createDummyFile('fail-url.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush(
+        {detail: 'File is too large'},
+        {status: 413, statusText: 'Payload Too Large'},
+      );
+
+      expect(service.totalFailed()).toBe(1);
+      const failedItem = service.uploadQueue()[0];
+      expect(failedItem.status).toBe(UploadStatus.FAILED);
+      expect(failedItem.errorMessage).toBe('File is too large');
+      expect(service.canClose()).toBeTrue();
+    });
+
+    it('should support retryUpload for failed items', () => {
+      const file = createDummyFile('retry.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush(
+        {detail: 'Network error'},
+        {status: 500, statusText: 'Error'},
+      );
+
+      expect(service.totalFailed()).toBe(1);
+      const itemId = service.uploadQueue()[0].id;
+
+      // Retry single failed upload
+      service.retryUpload(mockWorkspaceId, itemId);
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.GENERATING_URL);
+
+      const retryGenReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      retryGenReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-retry',
+        gcsUri: 'gs://test-bucket/retry.png',
+        fileUuid: 'retry-uuid',
+      });
+
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-retry',
+      );
+      putReq.flush(null, {status: 200, statusText: 'OK'});
+
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      finalizeReq.flush({id: 1});
+    });
+
+    it('should support retryAllFailed for multiple failed items', () => {
+      const files = [createDummyFile('f1.png'), createDummyFile('f2.png')];
+      service.uploadFiles(mockWorkspaceId, files);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      reqs.forEach(r =>
+        r.flush(
+          {detail: 'Backend failure'},
+          {status: 500, statusText: 'Error'},
+        ),
+      );
+
+      expect(service.totalFailed()).toBe(2);
+
+      service.retryAllFailed(mockWorkspaceId);
+
+      const retryReqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(retryReqs.length).toBe(2);
+      retryReqs.forEach(r =>
+        r.flush(
+          {detail: 'Backend failure'},
+          {status: 500, statusText: 'Error'},
+        ),
+      );
+    });
+
+    it('should not retryUpload if file has unsupported format', () => {
+      const invalidFile = createDummyFile('unsupported.pdf', 'application/pdf');
+      service.uploadFiles(mockWorkspaceId, [invalidFile]);
+
+      expect(service.totalFailed()).toBe(1);
+      const itemId = service.uploadQueue()[0].id;
+
+      service.retryUpload(mockWorkspaceId, itemId);
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.FAILED);
+      expect(service.uploadQueue()[0].errorMessage).toContain(
+        'Unsupported format',
+      );
+    });
+
+    it('should not retryAllFailed for items with unsupported format', () => {
+      const files = [
+        createDummyFile('valid.png'),
+        createDummyFile('unsupported.pdf', 'application/pdf'),
+      ];
+      service.uploadFiles(mockWorkspaceId, files);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush(
+        {detail: 'Network error'},
+        {status: 500, statusText: 'Error'},
+      );
+
+      expect(service.totalFailed()).toBe(2);
+
+      service.retryAllFailed(mockWorkspaceId);
+
+      // Only the valid.png should be retried (expecting one generate-upload-url request)
+      const retryReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      retryReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-retry',
+        gcsUri: 'gs://test-bucket/retry.png',
+        fileUuid: 'retry-uuid',
+      });
+
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-retry',
+      );
+      putReq.flush(null, {status: 200, statusText: 'OK'});
+
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      finalizeReq.flush({id: 1});
+
+      // The invalid file should remain FAILED
+      const invalidItem = service
+        .uploadQueue()
+        .find(i => i.filename === 'unsupported.pdf');
+      expect(invalidItem?.status).toBe(UploadStatus.FAILED);
+    });
+  });
+
+  describe('Individual Item Upload Cancellation', () => {
+    it('should cancel a queued file without triggering any request', () => {
+      const files = Array.from({length: 6}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(1);
+
+      const queuedItem = service
+        .uploadQueue()
+        .find(i => i.status === UploadStatus.QUEUED)!;
+      expect(queuedItem).toBeTruthy();
+
+      service.cancelUpload(queuedItem.id);
+
+      const updatedItem = service
+        .uploadQueue()
+        .find(i => i.id === queuedItem.id)!;
+      expect(updatedItem.status).toBe(UploadStatus.CANCELLED);
+      expect(service.queuedCount()).toBe(0);
+      expect(service.totalCancelled()).toBe(1);
+
+      // Clean up outstanding requests in the testing backend
+      httpMock
+        .match(() => true)
+        .forEach(req => req.error(new ProgressEvent('error')));
+    });
+
+    it('should cancel an active file, abort request, and trigger the next queued file', () => {
+      const files = Array.from({length: 6}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(1);
+
+      const activeItem = service
+        .uploadQueue()
+        .find(i => i.status === UploadStatus.GENERATING_URL)!;
+      expect(activeItem).toBeTruthy();
+
+      const reqsBefore = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqsBefore.length).toBe(5);
+
+      // Cancel the active item
+      service.cancelUpload(activeItem.id);
+
+      const updatedItem = service
+        .uploadQueue()
+        .find(i => i.id === activeItem.id)!;
+      expect(updatedItem.status).toBe(UploadStatus.CANCELLED);
+      expect(service.totalCancelled()).toBe(1);
+
+      // A slot should be released, so the 6th file (queued) should be triggered immediately
+      const newReqs = httpMock.match(
+        req =>
+          req.url === `${apiUrl}/generate-upload-url` &&
+          req.body?.filename === 'file_6.png',
+      );
+      expect(newReqs.length).toBe(1);
+      expect(newReqs[0].request.body.filename).toBe('file_6.png');
+
+      // Clean up outstanding requests in the testing backend
+      httpMock
+        .match(() => true)
+        .forEach(req => req.error(new ProgressEvent('error')));
+    });
+
+    it('should exclude cancelled and failed files from overall progress calculation', () => {
+      const files = [
+        createDummyFile('completed.png'),
+        createDummyFile('failed.png'),
+        createDummyFile('cancelled.png'),
+        createDummyFile('uploading.png'),
+      ];
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(4);
+
+      const items = service.uploadQueue();
+      const cancId = items[2].id;
+
+      // 1. Cancel file 3
+      service.cancelUpload(cancId);
+      expect(service.totalCancelled()).toBe(1);
+
+      // 2. Fail file 2
+      reqs[1].flush({detail: 'Failed'}, {status: 500, statusText: 'Error'});
+      expect(service.totalFailed()).toBe(1);
+
+      // 3. Complete file 1
+      reqs[0].flush({
+        uploadUrl: 'http://url1',
+        gcsUri: 'gs://uri1',
+      });
+      const put1 = httpMock.expectOne('http://url1');
+      put1.flush(null);
+      const fin1 = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      fin1.flush({id: 1});
+      expect(service.totalUploaded()).toBe(1);
+
+      // 4. Update file 4 progress to 50%
+      reqs[3].flush({
+        uploadUrl: 'http://url4',
+        gcsUri: 'gs://uri4',
+      });
+      const put4 = httpMock.expectOne('http://url4');
+      put4.event({
+        type: HttpEventType.UploadProgress,
+        loaded: 512,
+        total: 1024,
+      });
+
+      // Valid items: completed (100% progress) and uploading (50% progress)
+      // Overall progress: Math.round((100 + 50) / 2) = 75%
+      expect(service.overallProgress()).toBe(75);
+
+      // Clean up outstanding requests in the testing backend
+      httpMock
+        .match(() => true)
+        .forEach(req => req.error(new ProgressEvent('error')));
+    });
+  });
+
+  describe('SessionStorage Persistence & Reload Recovery', () => {
+    it('should sync queue state to sessionStorage without file binary blobs', () => {
+      const file = createDummyFile('sync.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const req = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      req.flush({detail: 'Pause'}, {status: 500, statusText: 'Error'});
+
+      const stored = sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+      expect(stored).toBeTruthy();
+
+      const parsed: UploadItem[] = JSON.parse(stored!);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].filename).toBe('sync.png');
+      expect(parsed[0].file).toBeUndefined();
+    });
+
+    it('should restore state on service instantiation and mark in-flight transfers as FAILED', () => {
+      const savedItems: UploadItem[] = [
+        {
+          id: '1',
+          filename: 'done.png',
+          size: 100,
+          mimeType: 'image/png',
+          status: UploadStatus.COMPLETED,
+          progress: 100,
+        },
+        {
+          id: '2',
+          filename: 'interrupted.png',
+          size: 200,
+          mimeType: 'image/png',
+          status: UploadStatus.UPLOADING,
+          progress: 45,
+        },
+      ];
+
+      sessionStorage.setItem(
+        MOCK_SESSION_STORAGE_UPLOAD_KEY,
+        JSON.stringify(savedItems),
+      );
+
+      // Re-instantiate service within injection context
+      const freshService = TestBed.runInInjectionContext(
+        () =>
+          new MediaUploadService(
+            TestBed.inject(MediaUploadService)['http'],
+            TestBed.inject(UserService),
+            TestBed.inject(Router),
+          ),
+      );
+
+      expect(freshService.totalCount()).toBe(2);
+      expect(freshService.totalUploaded()).toBe(1);
+      expect(freshService.totalFailed()).toBe(1);
+
+      const failedItem = freshService.uploadQueue().find(i => i.id === '2');
+      expect(failedItem?.status).toBe(UploadStatus.FAILED);
+      expect(failedItem?.errorMessage).toBe(
+        'Upload interrupted by page reload.',
+      );
+    });
+
+    it('should clear queue and remove sessionStorage key when clearQueue is invoked', () => {
+      const file = createDummyFile('clear.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush({detail: 'Error'}, {status: 400, statusText: 'Bad Request'});
+
+      expect(service.canClose()).toBeTrue();
+      service.clearQueue();
+
+      expect(service.uploadQueue()).toEqual([]);
+      expect(
+        sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY),
+      ).toBeNull();
+    });
+  });
+
+  describe('Route-based Cancellation on /login Navigation', () => {
+    it('should cancel all queued, in-flight, and failed uploads when navigating to /login', () => {
+      const files = [
+        createDummyFile('file0.png'), // Will complete
+        createDummyFile('file1.png'), // Will fail
+        createDummyFile('file2.png'), // Will remain in-flight (GENERATING_URL)
+        createDummyFile('file3.png'), // Will remain in-flight (UPLOADING)
+        createDummyFile('file4.png'), // Will remain in-flight (FINALIZING)
+        createDummyFile('file5.png'), // Will remain QUEUED
+        createDummyFile('file6.png'), // Will remain QUEUED
+        createDummyFile('file7.png'), // Will remain QUEUED
+      ];
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(3);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(5);
+
+      // f0: COMPLETED
+      reqs[0].flush({
+        uploadUrl: 'http://url0',
+        gcsUri: 'gs://uri0',
+      });
+      const put0 = httpMock.expectOne('http://url0');
+      put0.flush(null);
+      const fin0 = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      fin0.flush({id: 0});
+
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.COMPLETED);
+
+      // Now f5 starts GENERATING_URL because a slot opened up.
+      const reqForF5 = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+
+      // f1: FAILED
+      reqs[1].flush({detail: 'Some error'}, {status: 500, statusText: 'Error'});
+      expect(service.uploadQueue()[1].status).toBe(UploadStatus.FAILED);
+      expect(service.uploadQueue()[1].errorMessage).toBe('Some error');
+
+      // Now f6 starts GENERATING_URL because another slot opened up.
+      const reqForF6 = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+
+      // Now we have:
+      // f0: COMPLETED
+      // f1: FAILED
+      // f2: GENERATING_URL (reqs[2] is pending)
+      // f3: UPLOADING (transition from reqs[3])
+      reqs[3].flush({
+        uploadUrl: 'http://url3',
+        gcsUri: 'gs://uri3',
+      });
+      expect(service.uploadQueue()[3].status).toBe(UploadStatus.UPLOADING);
+
+      // f4: FINALIZING (transition from reqs[4])
+      reqs[4].flush({
+        uploadUrl: 'http://url4',
+        gcsUri: 'gs://uri4',
+      });
+      const put4 = httpMock.expectOne('http://url4');
+      put4.flush(null);
+      expect(service.uploadQueue()[4].status).toBe(UploadStatus.FINALIZING);
+
+      // f5: GENERATING_URL (reqForF5 is pending)
+      // f6: GENERATING_URL (reqForF6 is pending)
+      // f7: QUEUED (no slots since active are f2, f3, f4, f5, f6 -> 5 items in progress)
+      expect(service.uploadQueue()[7].status).toBe(UploadStatus.QUEUED);
+
+      // Now we navigate to /login by emitting event on router
+      routerEventsSubject.next(new NavigationEnd(1, '/login', '/login'));
+
+      // Let's verify statuses:
+      const queue = service.uploadQueue();
+      expect(queue[0].status).toBe(UploadStatus.COMPLETED);
+      expect(queue[1].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[1].errorMessage).toBeUndefined();
+      expect(queue[2].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[3].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[4].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[5].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[6].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[7].status).toBe(UploadStatus.CANCELLED);
+
+      expect(service.inProgressCount()).toBe(0);
+      expect(service.queuedCount()).toBe(0);
+      expect(service.isBatchFinished()).toBeTrue();
+
+      // Check sessionStorage sync
+      const stored = sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+      expect(stored).toBeTruthy();
+      const parsed: UploadItem[] = JSON.parse(stored!);
+      expect(parsed.length).toBe(8);
+      expect(parsed[0].status).toBe(UploadStatus.COMPLETED);
+      for (let i = 1; i <= 7; i++) {
+        expect(parsed[i].status).toBe(UploadStatus.CANCELLED);
+        expect(parsed[i].errorMessage).toBeUndefined();
+      }
+
+      // Verify that the explicitly matched/expected requests were also cancelled
+      expect(reqs[2].cancelled).toBeTrue();
+      expect(reqForF5.cancelled).toBeTrue();
+      expect(reqForF6.cancelled).toBeTrue();
+
+      // Pull all other open requests from the mock backend registry
+      const openReqs = httpMock.match(() => true);
+      expect(openReqs.length).toBe(2); // PUT http://url3 and POST finalize-upload
+      openReqs.forEach(req => {
+        expect(req.cancelled).toBeTrue();
+      });
+    });
+
+    it('should also trigger cancelAllForLogin if urlAfterRedirects starts with /login', () => {
+      const file = createDummyFile('file.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      routerEventsSubject.next(
+        new NavigationEnd(1, '/some-other-url', '/login?returnUrl=/dashboard'),
+      );
+
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.CANCELLED);
+      const stored = sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+      const parsed: UploadItem[] = JSON.parse(stored!);
+      expect(parsed[0].status).toBe(UploadStatus.CANCELLED);
+
+      // Pull all open requests (there should be 1: POST generate-upload-url)
+      const openReqs = httpMock.match(() => true);
+      expect(openReqs.length).toBe(1);
+      expect(openReqs[0].cancelled).toBeTrue();
+    });
+  });
+});

--- a/frontend/src/app/common/services/media-upload/media-upload.service.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.ts
@@ -1,0 +1,681 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HttpClient,
+  HttpEvent,
+  HttpEventType,
+  HttpHeaders,
+} from '@angular/common/http';
+import {computed, effect, Injectable, signal} from '@angular/core';
+import {NavigationEnd, Router} from '@angular/router';
+import {Subject, Subscription} from 'rxjs';
+import {filter} from 'rxjs/operators';
+import {environment} from '../../../../environments/environment';
+import {UserService} from '../user.service';
+
+export enum UploadStatus {
+  QUEUED = 'QUEUED',
+  GENERATING_URL = 'GENERATING_URL',
+  UPLOADING = 'UPLOADING',
+  FINALIZING = 'FINALIZING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}
+
+export interface UploadItem {
+  id: string;
+  file?: File;
+  filename: string;
+  size: number;
+  mimeType: string;
+  status: UploadStatus;
+  progress: number;
+  errorMessage?: string;
+  gcsUri?: string;
+  uploadUrl?: string;
+}
+
+export interface GenerateUploadUrlResponse {
+  uploadUrl: string;
+  gcsUri: string;
+  fileUuid: string;
+}
+
+export const SESSION_STORAGE_UPLOAD_KEY = 'cs_media_uploads_active_job';
+export const MAX_CONCURRENT_UPLOADS = 5;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MediaUploadService {
+  private readonly apiUrl = `${environment.backendURL}/source_assets`;
+
+  /**
+   * Primary Signal holding the active upload queue.
+   */
+  readonly uploadQueue = signal<UploadItem[]>([]);
+
+  /**
+   * Total count of successfully completed uploads in current queue.
+   */
+  readonly totalUploaded = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.COMPLETED)
+        .length,
+  );
+
+  /**
+   * Total count of failed uploads in current queue.
+   */
+  readonly totalFailed = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.FAILED)
+        .length,
+  );
+
+  /**
+   * Total count of cancelled uploads in current queue.
+   */
+  readonly totalCancelled = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.CANCELLED)
+        .length,
+  );
+
+  /**
+   * Total count of active uploads currently in progress.
+   */
+  readonly inProgressCount = computed(
+    () =>
+      this.uploadQueue().filter(item =>
+        [
+          UploadStatus.GENERATING_URL,
+          UploadStatus.UPLOADING,
+          UploadStatus.FINALIZING,
+        ].includes(item.status),
+      ).length,
+  );
+
+  /**
+   * Total count of items waiting in queue.
+   */
+  readonly queuedCount = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.QUEUED)
+        .length,
+  );
+
+  /**
+   * Total number of items in the upload queue.
+   */
+  readonly totalCount = computed(() => this.uploadQueue().length);
+
+  /**
+   * Overall percentage completed across all non-failed and non-cancelled items in queue (0 - 100).
+   */
+  readonly overallProgress = computed(() => {
+    const queue = this.uploadQueue();
+    const validItems = queue.filter(
+      item =>
+        item.status !== UploadStatus.FAILED &&
+        item.status !== UploadStatus.CANCELLED,
+    );
+    if (validItems.length === 0) return 0;
+    const totalProgress = validItems.reduce(
+      (sum, item) => sum + (item.progress || 0),
+      0,
+    );
+    return Math.round(totalProgress / validItems.length);
+  });
+
+  /**
+   * Indicates whether the close button can be activated (no active transfers in flight).
+   */
+  readonly canClose = computed(() => this.inProgressCount() === 0);
+
+  /**
+   * Indicates whether the widget should be visible (queue has items).
+   */
+  readonly hasActiveOrFinishedUploads = computed(
+    () => this.uploadQueue().length > 0,
+  );
+
+  /**
+   * Indicates if all items in batch have reached terminal state (COMPLETED or FAILED).
+   */
+  readonly isBatchFinished = computed(() => {
+    const queue = this.uploadQueue();
+    return (
+      queue.length > 0 &&
+      this.inProgressCount() === 0 &&
+      this.queuedCount() === 0
+    );
+  });
+
+  /**
+   * Subject emitted when an entire upload batch finishes processing.
+   */
+  readonly uploadBatchComplete$ = new Subject<void>();
+  private lastUploadCompleteNotified = signal<number>(0);
+
+  private activeSubscriptions = new Map<string, Subscription>();
+  private activeWorkspaceId?: number;
+  private isBatchRunning = false;
+  private beforeUnloadHandler = (event: BeforeUnloadEvent): string => {
+    event.preventDefault();
+    event.returnValue = '';
+    return '';
+  };
+
+  constructor(
+    private http: HttpClient,
+    private userService: UserService,
+    private router: Router,
+  ) {
+    this.restoreQueueFromSessionStorage();
+
+    // Listen to router events to cancel uploads when navigating to /login
+    this.router.events
+      .pipe(
+        filter(
+          (event): event is NavigationEnd => event instanceof NavigationEnd,
+        ),
+      )
+      .subscribe(event => {
+        if (
+          event.urlAfterRedirects.startsWith('/login') ||
+          event.url.startsWith('/login')
+        ) {
+          this.cancelAllForLogin();
+        }
+      });
+
+    // Effect to attach/detach window beforeunload listener when transfers are active
+    effect(() => {
+      const inProgress = this.inProgressCount();
+      if (inProgress > 0) {
+        window.addEventListener('beforeunload', this.beforeUnloadHandler);
+      } else {
+        window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      }
+    });
+  }
+
+  private getSessionStorageKey(): string {
+    return `cs_media_uploads_active_job_${this.userService.getUserDetails()?.email || 'default'}`;
+  }
+
+  readonly ALLOWED_MIME_TYPES = [
+    'image/png',
+    'video/mp4',
+    'audio/wav',
+    'audio/mpeg',
+    'audio/mp3',
+    'audio/ogg',
+    'audio/webm',
+  ];
+
+  isAllowedFileType(file: File): boolean {
+    if (this.ALLOWED_MIME_TYPES.includes(file.type)) return true;
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    if (ext === 'png' && (file.type === 'image/png' || !file.type)) return true;
+    if (ext === 'mp4' && (file.type === 'video/mp4' || !file.type)) return true;
+    if (['wav', 'mp3', 'ogg', 'webm', 'mpeg'].includes(ext || '')) return true;
+    return false;
+  }
+
+  allowedFileTypeMessage(file: File): string | null {
+    return this.isAllowedFileType(file)
+      ? null
+      : 'Unsupported format. Allowed: PNG, MP4, Audio (WAV, MP3, OGG, WEBM)';
+  }
+
+  /**
+   * Initiates multi-file upload for selected files.
+   */
+  uploadFiles(workspaceId: number, files: File[]): void {
+    if (!files || files.length === 0) return;
+    this.activeWorkspaceId = workspaceId;
+
+    const newItems: UploadItem[] = files.map(file => {
+      const errorMessage = this.allowedFileTypeMessage(file);
+      return {
+        id: this.generateUniqueId(),
+        file,
+        filename: file.name,
+        size: file.size,
+        mimeType: file.type || 'application/octet-stream',
+        status: !errorMessage ? UploadStatus.QUEUED : UploadStatus.FAILED,
+        progress: 0,
+        errorMessage: errorMessage || undefined,
+      };
+    });
+
+    this.isBatchRunning = true;
+    this.uploadQueue.update(current => [...current, ...newItems]);
+    this.syncSessionStorage();
+    this.processQueue(workspaceId);
+  }
+
+  /**
+   * Cancels an upload for a specific file ID.
+   * If in QUEUED state, marks status as CANCELLED without starting HTTP request.
+   * If in active state (GENERATING_URL, UPLOADING, FINALIZING), aborts the active HTTP request,
+   * marks status as CANCELLED, releases concurrency pool slot, and triggers next queued file.
+   */
+  cancelUpload(fileId: string): void {
+    const item = this.uploadQueue().find(i => i.id === fileId);
+    if (!item) return;
+
+    const sub = this.activeSubscriptions.get(fileId);
+    if (sub) {
+      sub.unsubscribe();
+      this.activeSubscriptions.delete(fileId);
+    }
+
+    const isUncompleted = [
+      UploadStatus.QUEUED,
+      UploadStatus.GENERATING_URL,
+      UploadStatus.UPLOADING,
+      UploadStatus.FINALIZING,
+      UploadStatus.FAILED,
+    ].includes(item.status);
+
+    if (isUncompleted) {
+      this.updateItem(fileId, {
+        status: UploadStatus.CANCELLED,
+        errorMessage: undefined,
+      });
+
+      if (this.activeWorkspaceId !== undefined) {
+        this.processQueue(this.activeWorkspaceId);
+      }
+      this.checkBatchCompletion();
+    }
+  }
+
+  private cancelAllForLogin(): void {
+    this.activeSubscriptions.forEach(sub => sub.unsubscribe());
+    this.activeSubscriptions.clear();
+
+    this.uploadQueue.update(current =>
+      current.map(item =>
+        [
+          UploadStatus.QUEUED,
+          UploadStatus.GENERATING_URL,
+          UploadStatus.UPLOADING,
+          UploadStatus.FINALIZING,
+          UploadStatus.FAILED,
+        ].includes(item.status)
+          ? {...item, status: UploadStatus.CANCELLED, errorMessage: undefined}
+          : item,
+      ),
+    );
+
+    this.syncSessionStorage();
+    this.checkBatchCompletion();
+  }
+
+  /**
+   * Retries uploading a specific failed or cancelled item.
+   */
+  retryUpload(workspaceId: number, itemId: string): void {
+    const item = this.uploadQueue().find(i => i.id === itemId);
+    if (
+      !item ||
+      (item.status !== UploadStatus.FAILED &&
+        item.status !== UploadStatus.CANCELLED)
+    ) {
+      return;
+    }
+    this.activeWorkspaceId = workspaceId;
+
+    const errorMessage = item.file
+      ? this.allowedFileTypeMessage(item.file)
+      : null;
+    const allowed = !errorMessage;
+
+    this.updateItem(itemId, {
+      status: allowed ? UploadStatus.QUEUED : UploadStatus.FAILED,
+      progress: 0,
+      errorMessage: errorMessage || undefined,
+    });
+
+    if (allowed) {
+      this.isBatchRunning = true;
+      this.processQueue(workspaceId);
+    }
+  }
+
+  /**
+   * Retries all failed uploads in the queue.
+   */
+  retryAllFailed(workspaceId: number): void {
+    const queue = this.uploadQueue();
+    const failedItems = queue.filter(i => i.status === UploadStatus.FAILED);
+    if (failedItems.length === 0) return;
+    this.activeWorkspaceId = workspaceId;
+
+    this.uploadQueue.update(current =>
+      current.map(item => {
+        if (item.status === UploadStatus.FAILED) {
+          const errorMessage = item.file
+            ? this.allowedFileTypeMessage(item.file)
+            : null;
+          const allowed = !errorMessage;
+          return {
+            ...item,
+            status: allowed ? UploadStatus.QUEUED : UploadStatus.FAILED,
+            progress: 0,
+            errorMessage: errorMessage || undefined,
+          };
+        }
+        return item;
+      }),
+    );
+
+    this.isBatchRunning = true;
+    this.syncSessionStorage();
+    this.processQueue(workspaceId);
+  }
+
+  /**
+   * Clears queue from memory and removes sessionStorage state.
+   */
+  clearQueue(): void {
+    if (!this.canClose()) return;
+    this.activeSubscriptions.forEach(sub => sub.unsubscribe());
+    this.activeSubscriptions.clear();
+    this.uploadQueue.set([]);
+    this.lastUploadCompleteNotified.set(0);
+    this.isBatchRunning = false;
+    try {
+      sessionStorage.removeItem(this.getSessionStorageKey());
+    } catch (e) {
+      console.error('Failed to clear sessionStorage upload key:', e);
+    }
+  }
+
+  /**
+   * Processes the upload queue maintaining max 5 concurrent uploads.
+   */
+  processQueue(workspaceId: number): void {
+    this.activeWorkspaceId = workspaceId;
+    const queue = this.uploadQueue();
+    const inProgress = this.inProgressCount();
+    const availableSlots = MAX_CONCURRENT_UPLOADS - inProgress;
+
+    if (availableSlots <= 0) return;
+
+    const queuedItems = queue.filter(
+      item => item.status === UploadStatus.QUEUED,
+    );
+    const itemsToStart = queuedItems.slice(0, availableSlots);
+
+    for (const item of itemsToStart) {
+      this.executeUpload(workspaceId, item);
+    }
+
+    this.checkBatchCompletion();
+  }
+
+  private executeUpload(workspaceId: number, item: UploadItem): void {
+    this.updateItem(item.id, {
+      status: UploadStatus.GENERATING_URL,
+      progress: 0,
+    });
+
+    const generatePayload = {
+      workspaceId,
+      filename: item.filename,
+      contentType: item.mimeType,
+      size: item.size,
+    };
+
+    const sub = this.http
+      .post<GenerateUploadUrlResponse>(
+        `${this.apiUrl}/generate-upload-url`,
+        generatePayload,
+      )
+      .subscribe({
+        next: res => {
+          this.activeSubscriptions.delete(item.id);
+          this.updateItem(item.id, {
+            status: UploadStatus.UPLOADING,
+            gcsUri: res.gcsUri,
+            uploadUrl: res.uploadUrl,
+          });
+          this.performGcsPut(workspaceId, item.id, res.uploadUrl, item);
+        },
+        error: err => {
+          this.activeSubscriptions.delete(item.id);
+          this.handleUploadError(
+            workspaceId,
+            item.id,
+            err.error?.detail ||
+              err.message ||
+              'Failed to generate signed upload URL',
+          );
+        },
+      });
+
+    this.activeSubscriptions.set(item.id, sub);
+  }
+
+  private performGcsPut(
+    workspaceId: number,
+    itemId: string,
+    uploadUrl: string,
+    item: UploadItem,
+  ): void {
+    if (!item.file) {
+      this.handleUploadError(
+        workspaceId,
+        itemId,
+        'File binary payload missing from memory.',
+      );
+      return;
+    }
+
+    const headers = new HttpHeaders({'Content-Type': item.mimeType});
+
+    const sub = this.http
+      .put(uploadUrl, item.file, {
+        headers,
+        reportProgress: true,
+        observe: 'events',
+      })
+      .subscribe({
+        next: (event: HttpEvent<unknown>) => {
+          if (event.type === HttpEventType.UploadProgress) {
+            const progress = event.total
+              ? Math.round((100 * event.loaded) / event.total)
+              : Math.min(99, Math.round((100 * event.loaded) / item.size));
+            this.updateItem(itemId, {progress});
+          } else if (event.type === HttpEventType.Response) {
+            this.activeSubscriptions.delete(itemId);
+            this.updateItem(itemId, {
+              status: UploadStatus.FINALIZING,
+              progress: 100,
+            });
+            this.finalizeUpload(workspaceId, itemId);
+          }
+        },
+        error: err => {
+          this.activeSubscriptions.delete(itemId);
+          this.handleUploadError(
+            workspaceId,
+            itemId,
+            err.error?.detail || err.message || 'Direct GCS upload failed.',
+          );
+        },
+      });
+
+    this.activeSubscriptions.set(itemId, sub);
+  }
+
+  private finalizeUpload(workspaceId: number, itemId: string): void {
+    const item = this.uploadQueue().find(i => i.id === itemId);
+    if (!item || !item.gcsUri) {
+      this.handleUploadError(
+        workspaceId,
+        itemId,
+        'Missing GCS URI for upload finalization.',
+      );
+      return;
+    }
+
+    const finalizePayload = {
+      workspaceId,
+      gcsUri: item.gcsUri,
+      filename: item.filename,
+      mimeType: item.mimeType,
+      size: item.size,
+      assetType: this.determineAssetType(item.mimeType),
+    };
+
+    const sub = this.http
+      .post(`${this.apiUrl}/finalize-upload`, finalizePayload)
+      .subscribe({
+        next: () => {
+          this.activeSubscriptions.delete(itemId);
+          this.updateItem(itemId, {
+            status: UploadStatus.COMPLETED,
+            progress: 100,
+          });
+          this.processQueue(workspaceId);
+        },
+        error: err => {
+          this.activeSubscriptions.delete(itemId);
+          this.handleUploadError(
+            workspaceId,
+            itemId,
+            err.error?.detail ||
+              err.message ||
+              'Failed to finalize asset upload.',
+          );
+        },
+      });
+
+    this.activeSubscriptions.set(itemId, sub);
+  }
+
+  private handleUploadError(
+    workspaceId: number,
+    itemId: string,
+    errorMessage: string,
+  ): void {
+    this.updateItem(itemId, {
+      status: UploadStatus.FAILED,
+      errorMessage,
+    });
+    this.processQueue(workspaceId);
+  }
+
+  private updateItem(id: string, changes: Partial<UploadItem>): void {
+    this.uploadQueue.update(queue =>
+      queue.map(item => (item.id === id ? {...item, ...changes} : item)),
+    );
+    this.syncSessionStorage();
+  }
+
+  private checkBatchCompletion(): void {
+    if (this.isBatchRunning && this.isBatchFinished()) {
+      this.isBatchRunning = false;
+      const currentUploaded = this.totalUploaded();
+      if (this.lastUploadCompleteNotified() !== currentUploaded) {
+        this.lastUploadCompleteNotified.set(currentUploaded);
+        this.uploadBatchComplete$.next();
+      }
+    }
+  }
+
+  private syncSessionStorage(): void {
+    try {
+      const queueToStore = this.uploadQueue().map(item => ({
+        id: item.id,
+        filename: item.filename,
+        size: item.size,
+        mimeType: item.mimeType,
+        status: item.status,
+        progress: item.progress,
+        errorMessage: item.errorMessage,
+        gcsUri: item.gcsUri,
+        uploadUrl: item.uploadUrl,
+      }));
+      sessionStorage.setItem(
+        this.getSessionStorageKey(),
+        JSON.stringify(queueToStore),
+      );
+    } catch (e) {
+      console.error('Failed to sync upload queue to sessionStorage:', e);
+    }
+  }
+
+  private restoreQueueFromSessionStorage(): void {
+    try {
+      const stored = sessionStorage.getItem(this.getSessionStorageKey());
+      if (!stored) return;
+
+      const items: UploadItem[] = JSON.parse(stored);
+      if (Array.isArray(items) && items.length > 0) {
+        const restored = items.map(item => {
+          // If transfer was interrupted mid-flight when page reloaded
+          if (
+            [
+              UploadStatus.GENERATING_URL,
+              UploadStatus.UPLOADING,
+              UploadStatus.FINALIZING,
+            ].includes(item.status)
+          ) {
+            return {
+              ...item,
+              status: UploadStatus.FAILED,
+              errorMessage: 'Upload interrupted by page reload.',
+            };
+          }
+          return item;
+        });
+        this.uploadQueue.set(restored);
+        this.lastUploadCompleteNotified.set(
+          restored.filter(item => item.status === UploadStatus.COMPLETED)
+            .length,
+        );
+      }
+    } catch (e) {
+      console.error('Failed to restore upload queue from sessionStorage:', e);
+    }
+  }
+
+  private determineAssetType(mimeType: string): string {
+    if (mimeType.startsWith('image/')) {
+      return 'generic_image';
+    }
+    if (mimeType.startsWith('video/')) {
+      return 'generic_video';
+    }
+    return 'generic_image';
+  }
+
+  private generateUniqueId(): string {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return `upload_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }
+}

--- a/frontend/src/app/common/shared.module.ts
+++ b/frontend/src/app/common/shared.module.ts
@@ -53,6 +53,7 @@ import {GalleryCardComponent} from './components/gallery-card/gallery-card.compo
 import {StudioDropdownComponent} from './components/studio-dropdown/studio-dropdown.component';
 import {StudioSearchFilterComponent} from './components/studio-search-filter/studio-search-filter.component';
 import {StudioDateRangeFilterComponent} from './components/studio-date-range-filter/studio-date-range-filter.component';
+import {UploadProgressWidgetComponent} from './components/upload-progress-widget/upload-progress-widget.component';
 import {TruncatePipe} from './pipes/truncate.pipe';
 
 const DECLARATIONS = [
@@ -71,6 +72,7 @@ const DECLARATIONS = [
   StudioDropdownComponent,
   StudioSearchFilterComponent,
   StudioDateRangeFilterComponent,
+  UploadProgressWidgetComponent,
   TruncatePipe,
   TagsManagementDialogComponent,
 ];

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.html
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.html
@@ -119,6 +119,26 @@
               <mat-icon class="mr-1">{{ showAdvancedFilters ? 'expand_less' : 'filter_list' }}</mat-icon>
               <span>Filters</span>
             </studio-button>
+
+            <!-- Upload Media Button & Hidden Input -->
+            <input
+              #fileInput
+              type="file"
+              multiple
+              accept="image/png,video/mp4,audio/wav,audio/mpeg,audio/mp3,audio/ogg,audio/webm"
+              class="hidden"
+              (change)="onFilesSelected($event)"
+            />
+            <studio-button
+              variant="primary"
+              size="small"
+              [disabled]="uploadService.inProgressCount() > 0"
+              (click)="fileInput.click()"
+              title="Upload media files"
+            >
+              <mat-icon class="mr-1">cloud_upload</mat-icon>
+              <span>Upload Media</span>
+            </studio-button>
           </div>
 
           <!-- Select All Button -->

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.spec.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,22 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+import {MatIconModule} from '@angular/material/icon';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {of} from 'rxjs';
 import {MediaGalleryComponent} from './media-gallery.component';
 import {GalleryService} from '../gallery.service';
-import {DomSanitizer} from '@angular/platform-browser';
-import {MatIconRegistry} from '@angular/material/icon';
 import {UserService} from '../../common/services/user.service';
-import {ElementRef, NgZone, NO_ERRORS_SCHEMA} from '@angular/core';
-import {MatIconModule} from '@angular/material/icon';
-import {of} from 'rxjs';
 import {WorkspaceStateService} from '../../services/workspace/workspace-state.service';
 import {TagsService} from '../../common/services/tags.service';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
 
 describe('MediaGalleryComponent', () => {
   let component: MediaGalleryComponent;
   let fixture: ComponentFixture<MediaGalleryComponent>;
+  let uploadService: MediaUploadService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -38,6 +39,7 @@ describe('MediaGalleryComponent', () => {
       imports: [HttpClientTestingModule, MatIconModule, NoopAnimationsModule],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
+        MediaUploadService,
         {
           provide: GalleryService,
           useValue: {
@@ -58,10 +60,9 @@ describe('MediaGalleryComponent', () => {
           useValue: {
             bypassSecurityTrustResourceUrl: (url: string) => url,
             bypassSecurityTrustUrl: (url: string) => url,
-            sanitize: (context: any, value: any) => value,
+            sanitize: (context: unknown, value: unknown) => value,
           },
         },
-
         {
           provide: UserService,
           useValue: {
@@ -95,11 +96,27 @@ describe('MediaGalleryComponent', () => {
 
     fixture = TestBed.createComponent(MediaGalleryComponent);
     component = fixture.componentInstance;
+    uploadService = TestBed.inject(MediaUploadService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should trigger MediaUploadService.uploadFiles when files are selected', () => {
+    spyOn(uploadService, 'uploadFiles');
+
+    const dummyFile = new File(['test'], 'demo.png', {type: 'image/png'});
+    const mockEvent = {
+      target: {
+        files: [dummyFile],
+        value: 'demo.png',
+      },
+    } as unknown as Event;
+
+    component.onFilesSelected(mockEvent);
+    expect(uploadService.uploadFiles).toHaveBeenCalledWith(1, [dummyFile]);
   });
 
   describe('ngOnInit filters restoration', () => {
@@ -116,7 +133,8 @@ describe('MediaGalleryComponent', () => {
       };
 
       const galleryService = TestBed.inject(GalleryService);
-      (galleryService as any).filtersState = mockState;
+      (galleryService as unknown as {filtersState: unknown}).filtersState =
+        mockState;
 
       component.ngOnInit();
 
@@ -136,7 +154,8 @@ describe('MediaGalleryComponent', () => {
 
     it('should use default values when no filtersState is stored', () => {
       const galleryService = TestBed.inject(GalleryService);
-      (galleryService as any).filtersState = null;
+      (galleryService as unknown as {filtersState: unknown}).filtersState =
+        null;
 
       component.ngOnInit();
 

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
@@ -1,4 +1,4 @@
-import {trigger, state, style, transition, animate} from '@angular/animations';
+import {trigger, style, transition, animate} from '@angular/animations';
 /**
  * Copyright 2025 Google LLC
  *
@@ -25,19 +25,16 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  ViewChild,
   Inject,
   PLATFORM_ID,
   HostListener,
 } from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
-import {MatCheckboxChange} from '@angular/material/checkbox';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatIconRegistry} from '@angular/material/icon';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
-import {Subscription, fromEvent, forkJoin, of} from 'rxjs';
-import {debounceTime, map, switchMap} from 'rxjs/operators';
+import {Subscription, forkJoin} from 'rxjs';
 import {MediaItemSelection} from '../../common/components/image-selector/image-selector.component';
 import {CopyToWorkspaceDialogComponent} from '../../common/components/copy-to-workspace-dialog/copy-to-workspace-dialog.component';
 import {DropdownOption} from '../../common/components/studio-dropdown/studio-dropdown.component';
@@ -56,6 +53,7 @@ import {AssignTagsDialogComponent} from '../../common/components/assign-tags-dia
 import {UserRolesEnum} from '../../common/models/user.model';
 import {TagsManagementDialogComponent} from '../../common/components/tags-management-dialog/tags-management-dialog.component';
 import {ConfirmationDialogComponent} from '../../common/components/confirmation-dialog/confirmation-dialog.component';
+import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
 
 @Component({
   selector: 'app-media-gallery',
@@ -129,6 +127,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
   private allImagesLoadedSubscription: Subscription | undefined;
   private loadingSubscription: Subscription | undefined;
   private resizeSubscription: Subscription | undefined;
+  private uploadBatchSubscription: Subscription | undefined;
   private _hostVisibilityObserver!: IntersectionObserver;
   private _scrollObserver!: IntersectionObserver;
   public userEmailFilter = '';
@@ -230,6 +229,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     private snackBar: MatSnackBar,
     public dialog: MatDialog,
     private tagsService: TagsService,
+    public uploadService: MediaUploadService,
     @Inject(PLATFORM_ID) platformId: Object,
   ) {
     this.isBrowser = isPlatformBrowser(platformId);
@@ -301,6 +301,11 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     this.allImagesLoadedSubscription =
       this.galleryService.allImagesLoaded.subscribe(loaded => {
         this.allImagesLoaded = loaded;
+      });
+
+    this.uploadBatchSubscription =
+      this.uploadService.uploadBatchComplete$.subscribe(() => {
+        this.searchTerm();
       });
 
     if (this.isBrowser) {
@@ -404,8 +409,20 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     this.resizeSubscription?.unsubscribe();
+    this.uploadBatchSubscription?.unsubscribe();
     this._hostVisibilityObserver?.disconnect();
     this._scrollObserver?.disconnect();
+  }
+
+  onFilesSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+      if (workspaceId !== null) {
+        this.uploadService.uploadFiles(workspaceId, Array.from(input.files));
+      }
+      input.value = '';
+    }
   }
 
   public trackByImage(index: number, image: GalleryItem): number | string {


### PR DESCRIPTION
Fixes [#517982291](https://b.corp.google.com/u/1/issues/517982291)

Implement a high-performance, resilient **Multi-File Upload System** for the **Media Gallery** in Creative Studio. The feature enables users to select and upload multiple media assets (images, videos, audio) simultaneously. 

Visually, an active **floating progress widget/tooltip** tracks individual and overall file upload progress in real time. The upload workflow follows the **GCS Direct Signed URL Strategy** used in the Brand Guidelines feature to maximize upload speed and reduce server load.

Key Requirements:
1. **Multi-File Upload Button in Media Gallery**: Add a new primary action button in the Media Gallery toolbar allowing batch selection of images, videos, and audio files.
2. **GCS Direct Signed URL Architecture**: Reuse the Brand Guidelines upload strategy (`initiate-upload` signed URL -> direct GCS PUT HTTP request -> `finalize-upload`).
3. **Concurrency Capped at 5 Files Simultaneously**:
   - The frontend `MediaUploadService` strictly limits active simultaneous uploads to **maximum 5 files at the same time**.
   - If more than 5 files are selected (e.g. 12 files), the first 5 start uploading immediately in parallel while the remaining 7 stay in `QUEUED` state. As each transfer completes or fails, the next queued file automatically begins processing.
4. **Floating Progress Tooltip/Widget**: Create an active floating widget rendered at the app layout level ([app.component.html](~/code/gcc-creative-studio/frontend/src/app/app.component.html)) that displays batch progress, individual file statuses, transfer rates, and completion/error indicators. The overall batch progress percentage and progress bar calculation must **exclude failed (`FAILED`) and cancelled (`CANCELLED`) files** (calculating progress only across active, queued, and successfully completed files).
5. **Header Indicators for Success & Failures**: Tooltip header displays summary counters for **total files uploaded** (successful count) and **total failed indicator** (failed count).
6. **Smart Close Button & Queue Clearing**:
   - Include a Close Button (`close` icon).
   - **Disabled** while at least one file is currently in progress (`GENERATING_URL` or `UPLOADING`).
   - **Enabled** once all files in the batch are finished (either completed or failed).
   - Clicking Close clears the upload list/queue from memory and `sessionStorage`.
7. **Filename Status Visibility & Re-login / Reload Persistence**:
   - Display success or failed filenames explicitly in the list so users can immediately identify which files need to be re-uploaded.
   - Preserve completed and failed upload states in `sessionStorage` so if a user reloads or re-logins, failed filenames and status indicators are retained and visible.
8. **Minimize & Maximize Controls**: Support collapsing the tooltip into a compact floating status pill/badge or expanding it to full detail mode without interrupting active transfers.
9. **Route Navigation Persistence**: Upload jobs remain active and visible in the floating widget while the user navigates across different views and routes within the web application.
10. **Tab Unload Protection**: Register a `beforeunload` window listener while uploads are in progress to warn users before closing or refreshing the tab.
11. **Individual Item Upload Cancellation**: Provide a cancel action button (`close` / `cancel` icon) on each uncompleted file item (statuses `QUEUED`, `GENERATING_URL`, or `UPLOADING`). Cancelling an in-progress upload aborts the HTTP request, sets item status to `CANCELLED`, and releases the concurrency pool slot so the next queued file starts immediately.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
