### PR TITLE
Add the ability to upload images, video, audio directly to the gallery

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,8 @@ Before you begin, ensure you have the following tools installed on your system:
 2.  After you create your account:
     - You create a fork of [Open Source Repo](https://github.com/GoogleCloudPlatform/gcc-creative-studio/tree/main)
     - You see this video [How to Deploy Creative Studio.mp4](./screenshots/how_to_deploy_creative_studio.mp4) and deploy Creative Studio into your GCP Account environment, using CloudShell for simplicity.
+3.  Ensure required Google Cloud APIs are enabled in your project:
+    - **Google Drive API**: Ensure `drive.googleapis.com` is enabled in your project via the [Google Cloud Console API Overview](https://console.developers.google.com/apis/api/drive.googleapis.com/overview) if planning to use media gallery upload from Drive.
 
 ## 3. Add env variables to repo where we’ll work
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Regarding the dependencies of the APIs and Services we’ll use (the Google APIs
 - `cloudbuild.googleapis.com` (Cloud Build)
 - `cloudfunctions.googleapis.com` (Cloud Functions)
 - `compute.googleapis.com` (Compute Engine)
+- `drive.googleapis.com` (Google Drive API)
 - `firebase.googleapis.com` (Firebase)
 - `sqladmin.googleapis.com` (Cloud SQL)
 - `iamcredentials.googleapis.com` (IAM Service API)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "google-cloud-workflows>=1.19.0",
     "google-api-python-client>=2.187.0",
     "httpx>=0.27.0",
-    "pillow-heif>=0.18.0",
+    "heic2png>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "google-cloud-workflows>=1.19.0",
     "google-api-python-client>=2.187.0",
     "httpx>=0.27.0",
+    "pillow-heif>=0.18.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/brand_guidelines/brand_guideline_controller.py
+++ b/backend/src/brand_guidelines/brand_guideline_controller.py
@@ -76,7 +76,7 @@ async def generate_upload_url(
         )
     if request_dto.size > MAX_UPLOAD_SIZE_BYTES:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"File is too large. Maximum size is {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)}MB.",
         )
 

--- a/backend/src/common/base_dto.py
+++ b/backend/src/common/base_dto.py
@@ -25,6 +25,10 @@ class MimeTypeEnum(str, Enum):
 
     IMAGE_JPEG = "image/jpeg"
     IMAGE_PNG = "image/png"
+    IMAGE_WEBP = "image/webp"
+    IMAGE_HEIC = "image/heic"
+    IMAGE_HEIF = "image/heif"
+    IMAGE_AVIF = "image/avif"
     VIDEO_MP4 = "video/mp4"
     AUDIO_WAV = "audio/wav"
     AUDIO_MPEG = "audio/mpeg"

--- a/backend/src/source_assets/dto/finalize_upload_dto.py
+++ b/backend/src/source_assets/dto/finalize_upload_dto.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydantic import Field
+
+from src.common.base_dto import AspectRatioEnum, BaseDto
+from src.source_assets.schema.source_asset_model import (
+    AssetScopeEnum,
+    AssetTypeEnum,
+)
+
+
+class FinalizeSourceAssetUploadDto(BaseDto):
+    """Request DTO to complete asset registration after successful GCS upload."""
+
+    workspace_id: int = Field(description="The target workspace ID.")
+    gcs_uri: str = Field(
+        description="The gs:// path where the file was uploaded."
+    )
+    filename: str = Field(description="The original filename of the asset.")
+    mime_type: str = Field(description="The MIME type of the asset.")
+    size: int = Field(gt=0, description="The size of the file in bytes.")
+    asset_type: AssetTypeEnum | None = Field(
+        default=None, description="Asset type classification."
+    )
+    aspect_ratio: AspectRatioEnum | None = Field(
+        default=None, description="Aspect ratio of the media asset."
+    )
+    scope: AssetScopeEnum | None = Field(
+        default=None, description="Scope of the asset."
+    )

--- a/backend/src/source_assets/dto/generate_upload_url_dto.py
+++ b/backend/src/source_assets/dto/generate_upload_url_dto.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pydantic import Field
+
+from src.common.base_dto import BaseDto
+
+
+class GenerateSourceAssetUploadUrlDto(BaseDto):
+    """Request body to generate a signed URL for direct source asset upload."""
+
+    workspace_id: int = Field(description="The target workspace ID.")
+    filename: str = Field(description="The name of the file to be uploaded.")
+    content_type: str = Field(
+        description="The MIME type of the file (e.g., 'image/png').",
+    )
+    size: int = Field(gt=0, description="The size of the file in bytes.")
+
+
+class GenerateSourceAssetUploadUrlResponseDto(BaseDto):
+    """Response containing the signed URL, GCS URI, and file UUID."""
+
+    upload_url: str = Field(
+        description="The GCS v4 signed URL for the PUT request.",
+    )
+    gcs_uri: str = Field(
+        description="The gs:// path where the file will be stored."
+    )
+    file_uuid: str = Field(
+        description="The generated unique UUID for the upload session."
+    )

--- a/backend/src/source_assets/source_asset_controller.py
+++ b/backend/src/source_assets/source_asset_controller.py
@@ -27,7 +27,11 @@ from fastapi import (
 )
 
 from src.auth.auth_guard import RoleChecker, get_current_user
-from src.common.base_dto import AspectRatioEnum, GenerationModelEnum
+from src.common.base_dto import (
+    AspectRatioEnum,
+    GenerationModelEnum,
+    MimeTypeEnum,
+)
 from src.common.dto.pagination_response_dto import PaginationResponseDto
 from src.source_assets.dto.finalize_upload_dto import (
     FinalizeSourceAssetUploadDto,
@@ -51,6 +55,19 @@ from src.users.user_model import UserModel, UserRoleEnum
 from src.workspaces.workspace_auth_guard import WorkspaceAuth
 
 MAX_UPLOAD_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB
+
+ALLOWED_MIME_TYPES = {
+    MimeTypeEnum.IMAGE_PNG.value,
+    MimeTypeEnum.IMAGE_JPEG.value,
+    "image/jpg",
+    MimeTypeEnum.IMAGE_WEBP.value,
+    MimeTypeEnum.VIDEO_MP4.value,
+    MimeTypeEnum.AUDIO_WAV.value,
+    MimeTypeEnum.AUDIO_MPEG.value,
+    MimeTypeEnum.AUDIO_MP3.value,
+    MimeTypeEnum.AUDIO_OGG.value,
+    MimeTypeEnum.AUDIO_WEBM.value,
+}
 
 router = APIRouter(
     prefix="/api/source_assets",
@@ -88,20 +105,8 @@ async def generate_source_asset_upload_url(
             detail=f"File is too large. Maximum size is {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)}MB.",
         )
 
-    allowed_mime_types = {
-        "image/png",
-        "image/jpeg",
-        "image/jpg",
-        "image/webp",
-        "video/mp4",
-        "audio/wav",
-        "audio/mpeg",
-        "audio/mp3",
-        "audio/ogg",
-        "audio/webm",
-    }
     content_type = request_dto.content_type.split(";")[0].strip().lower()
-    if content_type not in allowed_mime_types:
+    if content_type not in ALLOWED_MIME_TYPES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Unsupported file format.",

--- a/backend/src/source_assets/source_asset_controller.py
+++ b/backend/src/source_assets/source_asset_controller.py
@@ -81,7 +81,6 @@ router = APIRouter(
 )
 
 
-# code similar to: backend/src/brand_guidelines/brand_guideline_controller.py
 @router.post(
     "/generate-upload-url",
     response_model=GenerateSourceAssetUploadUrlResponseDto,
@@ -93,7 +92,10 @@ async def generate_source_asset_upload_url(
     service: SourceAssetService = Depends(),
     workspace_auth: WorkspaceAuth = Depends(),
 ):
-    """Generates a secure, short-lived signed URL to upload a source asset directly to GCS."""
+    """Generates a secure, short-lived signed URL to upload a source asset directly to GCS.
+
+    Uses same strategy as: backend/src/brand_guidelines/brand_guideline_controller.py
+    """
     await workspace_auth.authorize(
         workspace_id=request_dto.workspace_id,
         user=current_user,

--- a/backend/src/source_assets/source_asset_controller.py
+++ b/backend/src/source_assets/source_asset_controller.py
@@ -29,6 +29,13 @@ from fastapi import (
 from src.auth.auth_guard import RoleChecker, get_current_user
 from src.common.base_dto import AspectRatioEnum, GenerationModelEnum
 from src.common.dto.pagination_response_dto import PaginationResponseDto
+from src.source_assets.dto.finalize_upload_dto import (
+    FinalizeSourceAssetUploadDto,
+)
+from src.source_assets.dto.generate_upload_url_dto import (
+    GenerateSourceAssetUploadUrlDto,
+    GenerateSourceAssetUploadUrlResponseDto,
+)
 from src.source_assets.dto.source_asset_response_dto import (
     SourceAssetResponseDto,
 )
@@ -43,6 +50,8 @@ from src.users.repository.user_repository import UserRepository
 from src.users.user_model import UserModel, UserRoleEnum
 from src.workspaces.workspace_auth_guard import WorkspaceAuth
 
+MAX_UPLOAD_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB
+
 router = APIRouter(
     prefix="/api/source_assets",
     tags=["User Assets"],
@@ -53,6 +62,77 @@ router = APIRouter(
         ),
     ],
 )
+
+
+# code similar to: backend/src/brand_guidelines/brand_guideline_controller.py
+@router.post(
+    "/generate-upload-url",
+    response_model=GenerateSourceAssetUploadUrlResponseDto,
+    summary="Get a Signed URL for Direct Source Asset Upload",
+)
+async def generate_source_asset_upload_url(
+    request_dto: GenerateSourceAssetUploadUrlDto,
+    current_user: UserModel = Depends(get_current_user),
+    service: SourceAssetService = Depends(),
+    workspace_auth: WorkspaceAuth = Depends(),
+):
+    """Generates a secure, short-lived signed URL to upload a source asset directly to GCS."""
+    await workspace_auth.authorize(
+        workspace_id=request_dto.workspace_id,
+        user=current_user,
+    )
+
+    if request_dto.size > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=f"File is too large. Maximum size is {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)}MB.",
+        )
+
+    allowed_mime_types = {
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "video/mp4",
+        "audio/wav",
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/ogg",
+        "audio/webm",
+    }
+    if request_dto.content_type.lower() not in allowed_mime_types:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported file format.",
+        )
+
+    return await service.generate_signed_upload_url(
+        request_dto=request_dto,
+        current_user=current_user,
+    )
+
+
+@router.post(
+    "/finalize-upload",
+    response_model=SourceAssetResponseDto,
+    status_code=status.HTTP_201_CREATED,
+    summary="Finalize Direct Source Asset Upload",
+)
+async def finalize_source_asset_upload(
+    request_dto: FinalizeSourceAssetUploadDto,
+    current_user: UserModel = Depends(get_current_user),
+    service: SourceAssetService = Depends(),
+    workspace_auth: WorkspaceAuth = Depends(),
+):
+    """Finalizes registration of a source asset in the database after direct GCS upload."""
+    await workspace_auth.authorize(
+        workspace_id=request_dto.workspace_id,
+        user=current_user,
+    )
+
+    return await service.finalize_direct_upload(
+        request_dto=request_dto,
+        current_user=current_user,
+    )
 
 
 @router.post("/upload", response_model=SourceAssetResponseDto)

--- a/backend/src/source_assets/source_asset_controller.py
+++ b/backend/src/source_assets/source_asset_controller.py
@@ -90,6 +90,9 @@ async def generate_source_asset_upload_url(
 
     allowed_mime_types = {
         "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/webp",
         "video/mp4",
         "audio/wav",
         "audio/mpeg",

--- a/backend/src/source_assets/source_asset_controller.py
+++ b/backend/src/source_assets/source_asset_controller.py
@@ -90,8 +90,6 @@ async def generate_source_asset_upload_url(
 
     allowed_mime_types = {
         "image/png",
-        "image/jpeg",
-        "image/jpg",
         "video/mp4",
         "audio/wav",
         "audio/mpeg",
@@ -99,7 +97,8 @@ async def generate_source_asset_upload_url(
         "audio/ogg",
         "audio/webm",
     }
-    if request_dto.content_type.lower() not in allowed_mime_types:
+    content_type = request_dto.content_type.split(";")[0].strip().lower()
+    if content_type not in allowed_mime_types:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Unsupported file format.",

--- a/backend/src/source_assets/source_asset_service.py
+++ b/backend/src/source_assets/source_asset_service.py
@@ -37,6 +37,13 @@ from src.common.storage_service import GcsService
 from src.images.dto.upscale_imagen_dto import UpscaleImagenDto
 from src.images.imagen_service import ImagenService
 from src.multimodal.gemini_service import GeminiService
+from src.source_assets.dto.finalize_upload_dto import (
+    FinalizeSourceAssetUploadDto,
+)
+from src.source_assets.dto.generate_upload_url_dto import (
+    GenerateSourceAssetUploadUrlDto,
+    GenerateSourceAssetUploadUrlResponseDto,
+)
 from src.source_assets.dto.source_asset_response_dto import (
     SourceAssetResponseDto,
 )
@@ -499,6 +506,103 @@ class SourceAssetService:
             titles=final_titles,
             descriptions=final_descriptions,
         )
+        created_asset = await self.repo.create(new_asset)
+        new_asset.id = created_asset.id
+
+        return await self._create_asset_response(new_asset)
+
+    # code similar to: backend/src/brand_guidelines/brand_guideline_service.py
+    async def generate_signed_upload_url(
+        self,
+        request_dto: GenerateSourceAssetUploadUrlDto,
+        current_user: UserModel,
+    ) -> GenerateSourceAssetUploadUrlResponseDto:
+        """Generates a GCS v4 signed URL for a client-side direct source asset upload."""
+        file_uuid = str(uuid.uuid4())
+        destination_blob_name = f"source_assets/{current_user.id}/uploads/{file_uuid}/{request_dto.filename}"
+
+        signed_url, gcs_uri = await asyncio.to_thread(
+            self.iam_signer.generate_v4_upload_signed_url,
+            destination_blob_name,
+            request_dto.content_type,
+            self.gcs_service.bucket_name,
+        )
+
+        if not signed_url or not gcs_uri:
+            raise HTTPException(
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                "Could not generate upload URL.",
+            )
+
+        return GenerateSourceAssetUploadUrlResponseDto(
+            upload_url=signed_url,
+            gcs_uri=gcs_uri,
+            file_uuid=file_uuid,
+        )
+
+    async def finalize_direct_upload(
+        self,
+        request_dto: FinalizeSourceAssetUploadDto,
+        current_user: UserModel,
+    ) -> SourceAssetResponseDto:
+        """Finalizes registration of a source asset uploaded directly to GCS."""
+        content_type = request_dto.mime_type or ""
+        if content_type.startswith("video/"):
+            mime_type_enum = MimeTypeEnum.VIDEO_MP4
+        elif content_type.startswith("audio/"):
+            if content_type in ["audio/mpeg", "audio/mp3"]:
+                mime_type_enum = MimeTypeEnum.AUDIO_MPEG
+            elif content_type == "audio/wav":
+                mime_type_enum = MimeTypeEnum.AUDIO_WAV
+            elif content_type == "audio/ogg":
+                mime_type_enum = MimeTypeEnum.AUDIO_OGG
+            elif content_type == "audio/webm":
+                mime_type_enum = MimeTypeEnum.AUDIO_WEBM
+            else:
+                mime_type_enum = MimeTypeEnum.AUDIO_MPEG
+        else:
+            mime_type_enum = MimeTypeEnum.IMAGE_PNG
+
+        is_admin = UserRoleEnum.ADMIN in current_user.roles
+        final_scope = AssetScopeEnum.PRIVATE
+        if is_admin:
+            final_scope = request_dto.scope or AssetScopeEnum.PRIVATE
+        elif request_dto.scope and request_dto.scope != AssetScopeEnum.PRIVATE:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only administrators can set a non-private scope.",
+            )
+
+        if request_dto.asset_type:
+            final_asset_type = request_dto.asset_type
+        else:
+            if content_type.startswith("video/"):
+                final_asset_type = AssetTypeEnum.GENERIC_VIDEO
+            else:
+                final_asset_type = AssetTypeEnum.GENERIC_IMAGE
+
+        final_aspect_ratio = (
+            request_dto.aspect_ratio or AspectRatioEnum.RATIO_1_1
+        )
+
+        file_hash = hashlib.sha256(
+            request_dto.gcs_uri.encode("utf-8")
+        ).hexdigest()
+
+        new_asset = SourceAssetModel(
+            workspace_id=request_dto.workspace_id,
+            user_id=current_user.id,
+            aspect_ratio=final_aspect_ratio,
+            original_gcs_uri=request_dto.gcs_uri,
+            gcs_uri=request_dto.gcs_uri,
+            thumbnail_gcs_uri=None,
+            original_filename=request_dto.filename or "untitled",
+            mime_type=mime_type_enum,
+            file_hash=file_hash,
+            scope=final_scope,
+            asset_type=final_asset_type,
+        )
+
         created_asset = await self.repo.create(new_asset)
         new_asset.id = created_asset.id
 

--- a/backend/src/source_assets/source_asset_service.py
+++ b/backend/src/source_assets/source_asset_service.py
@@ -24,6 +24,9 @@ import uuid
 
 from fastapi import Depends, HTTPException, UploadFile, status
 from PIL import Image as PILImage
+import pillow_heif
+
+pillow_heif.register_heif_opener()
 
 from src.auth.iam_signer_credentials_service import IamSignerCredentials
 from src.common.base_dto import (
@@ -153,6 +156,26 @@ class SourceAssetService:
 
         logger.info("Deduced aspect ratio as %s", closest_enum.value)
         return closest_enum
+
+    def _determine_mime_type_enum(self, content_type: str) -> MimeTypeEnum:
+        """Determines the appropriate MimeTypeEnum for a given content type string."""
+        if content_type.startswith("video/"):
+            return MimeTypeEnum.VIDEO_MP4
+        if content_type.startswith("audio/"):
+            if content_type in ["audio/mpeg", "audio/mp3"]:
+                return MimeTypeEnum.AUDIO_MPEG
+            if content_type == "audio/wav":
+                return MimeTypeEnum.AUDIO_WAV
+            if content_type == "audio/ogg":
+                return MimeTypeEnum.AUDIO_OGG
+            if content_type == "audio/webm":
+                return MimeTypeEnum.AUDIO_WEBM
+            return MimeTypeEnum.AUDIO_MPEG
+        if content_type in ["image/jpeg", "image/jpg"]:
+            return MimeTypeEnum.IMAGE_JPEG
+        if content_type == "image/webp":
+            return MimeTypeEnum.IMAGE_WEBP
+        return MimeTypeEnum.IMAGE_PNG
 
     async def _create_asset_response(
         self,
@@ -435,23 +458,7 @@ class SourceAssetService:
         # 4. Create and save the new UserAsset document
         # Determine mime_type based on content_type
         content_type = mime_type or ""
-        if content_type.startswith("video/"):
-            mime_type = MimeTypeEnum.VIDEO_MP4
-        elif content_type.startswith("audio/"):
-            # Map common audio types to enum values
-            if content_type in ["audio/mpeg", "audio/mp3"]:
-                mime_type = MimeTypeEnum.AUDIO_MPEG
-            elif content_type == "audio/wav":
-                mime_type = MimeTypeEnum.AUDIO_WAV
-            elif content_type == "audio/ogg":
-                mime_type = MimeTypeEnum.AUDIO_OGG
-            elif content_type == "audio/webm":
-                mime_type = MimeTypeEnum.AUDIO_WEBM
-            else:
-                # Default to MPEG for unknown audio types
-                mime_type = MimeTypeEnum.AUDIO_MPEG
-        else:
-            mime_type = MimeTypeEnum.IMAGE_PNG
+        mime_type = self._determine_mime_type_enum(content_type)
 
         is_admin = UserRoleEnum.ADMIN in user.roles
         final_scope = AssetScopeEnum.PRIVATE
@@ -519,7 +526,7 @@ class SourceAssetService:
     ) -> GenerateSourceAssetUploadUrlResponseDto:
         """Generates a GCS v4 signed URL for a client-side direct source asset upload."""
         file_uuid = str(uuid.uuid4())
-        destination_blob_name = f"source_assets/{current_user.id}/uploads/{file_uuid}/{request_dto.filename}"
+        destination_blob_name = f"source_assets/{current_user.id}/uploads/{file_uuid}/{os.path.basename(request_dto.filename)}"
 
         signed_url, gcs_uri = await asyncio.to_thread(
             self.iam_signer.generate_v4_upload_signed_url,
@@ -547,27 +554,16 @@ class SourceAssetService:
     ) -> SourceAssetResponseDto:
         """Finalizes registration of a source asset uploaded directly to GCS."""
         expected_prefix = f"gs://{self.gcs_service.bucket_name}/source_assets/{current_user.id}/"
-        if not request_dto.gcs_uri.startswith(expected_prefix):
+        if (
+            not request_dto.gcs_uri.startswith(expected_prefix)
+            or ".." in request_dto.gcs_uri
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid GCS URI path.",
             )
         content_type = request_dto.mime_type or ""
-        if content_type.startswith("video/"):
-            mime_type_enum = MimeTypeEnum.VIDEO_MP4
-        elif content_type.startswith("audio/"):
-            if content_type in ["audio/mpeg", "audio/mp3"]:
-                mime_type_enum = MimeTypeEnum.AUDIO_MPEG
-            elif content_type == "audio/wav":
-                mime_type_enum = MimeTypeEnum.AUDIO_WAV
-            elif content_type == "audio/ogg":
-                mime_type_enum = MimeTypeEnum.AUDIO_OGG
-            elif content_type == "audio/webm":
-                mime_type_enum = MimeTypeEnum.AUDIO_WEBM
-            else:
-                mime_type_enum = MimeTypeEnum.AUDIO_MPEG
-        else:
-            mime_type_enum = MimeTypeEnum.IMAGE_PNG
+        mime_type_enum = self._determine_mime_type_enum(content_type)
 
         is_admin = UserRoleEnum.ADMIN in current_user.roles
         final_scope = AssetScopeEnum.PRIVATE

--- a/backend/src/source_assets/source_asset_service.py
+++ b/backend/src/source_assets/source_asset_service.py
@@ -24,9 +24,6 @@ import uuid
 
 from fastapi import Depends, HTTPException, UploadFile, status
 from PIL import Image as PILImage
-import pillow_heif
-
-pillow_heif.register_heif_opener()
 
 from src.auth.iam_signer_credentials_service import IamSignerCredentials
 from src.common.base_dto import (
@@ -579,11 +576,10 @@ class SourceAssetService:
 
         if request_dto.asset_type:
             final_asset_type = request_dto.asset_type
+        elif content_type.startswith("video/"):
+            final_asset_type = AssetTypeEnum.GENERIC_VIDEO
         else:
-            if content_type.startswith("video/"):
-                final_asset_type = AssetTypeEnum.GENERIC_VIDEO
-            else:
-                final_asset_type = AssetTypeEnum.GENERIC_IMAGE
+            final_asset_type = AssetTypeEnum.GENERIC_IMAGE
 
         final_aspect_ratio = (
             request_dto.aspect_ratio or AspectRatioEnum.RATIO_1_1
@@ -614,7 +610,7 @@ class SourceAssetService:
         return await self._create_asset_response(new_asset)
 
     async def convert_to_png(self, file: UploadFile) -> bytes:
-        """Converts an uploaded image file to PNG format in memory."""
+        """Converts an uploaded image file (including HEIC/HEIF) to PNG format in memory."""
         try:
             contents = await file.read()
             if not contents:
@@ -622,6 +618,40 @@ class SourceAssetService:
                     status.HTTP_400_BAD_REQUEST,
                     "Cannot convert an empty file.",
                 )
+
+            filename = file.filename or ""
+            content_type = file.content_type or ""
+            is_heic = filename.lower().endswith(
+                (".heic", ".heif")
+            ) or content_type.lower() in ["image/heic", "image/heif"]
+
+            if is_heic:
+                import tempfile
+                from heic2png import HEIC2PNG
+
+                with tempfile.NamedTemporaryFile(
+                    suffix=".heic", delete=False
+                ) as temp_in:
+                    temp_in.write(contents)
+                    temp_in_path = temp_in.name
+
+                try:
+                    heic_img = HEIC2PNG(temp_in_path, overwrite=True)
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".png", delete=False
+                    ) as temp_out:
+                        temp_out_path = temp_out.name
+
+                    try:
+                        heic_img.save(temp_out_path)
+                        with open(temp_out_path, "rb") as f:
+                            return f.read()
+                    finally:
+                        if os.path.exists(temp_out_path):
+                            os.remove(temp_out_path)
+                finally:
+                    if os.path.exists(temp_in_path):
+                        os.remove(temp_in_path)
 
             pil_image = PILImage.open(io.BytesIO(contents))
 
@@ -636,6 +666,8 @@ class SourceAssetService:
             with io.BytesIO() as output:
                 pil_image.save(output, format="PNG")
                 return output.getvalue()
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error("Failed to convert image to PNG: %s", e, exc_info=True)
             raise HTTPException(

--- a/backend/src/source_assets/source_asset_service.py
+++ b/backend/src/source_assets/source_asset_service.py
@@ -546,6 +546,12 @@ class SourceAssetService:
         current_user: UserModel,
     ) -> SourceAssetResponseDto:
         """Finalizes registration of a source asset uploaded directly to GCS."""
+        expected_prefix = f"gs://{self.gcs_service.bucket_name}/source_assets/{current_user.id}/"
+        if not request_dto.gcs_uri.startswith(expected_prefix):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid GCS URI path.",
+            )
         content_type = request_dto.mime_type or ""
         if content_type.startswith("video/"):
             mime_type_enum = MimeTypeEnum.VIDEO_MP4
@@ -585,6 +591,7 @@ class SourceAssetService:
             request_dto.aspect_ratio or AspectRatioEnum.RATIO_1_1
         )
 
+        # Fallback to hashing the GCS URI as a unique placeholder because the file content is not available on the server
         file_hash = hashlib.sha256(
             request_dto.gcs_uri.encode("utf-8")
         ).hexdigest()

--- a/backend/src/source_assets/source_asset_service.py
+++ b/backend/src/source_assets/source_asset_service.py
@@ -518,13 +518,15 @@ class SourceAssetService:
 
         return await self._create_asset_response(new_asset)
 
-    # code similar to: backend/src/brand_guidelines/brand_guideline_service.py
     async def generate_signed_upload_url(
         self,
         request_dto: GenerateSourceAssetUploadUrlDto,
         current_user: UserModel,
     ) -> GenerateSourceAssetUploadUrlResponseDto:
-        """Generates a GCS v4 signed URL for a client-side direct source asset upload."""
+        """Generates a GCS v4 signed URL for a client-side direct source asset upload.
+
+        Uses same strategy as: backend/src/brand_guidelines/brand_guideline_service.py
+        """
         file_uuid = str(uuid.uuid4())
         destination_blob_name = f"source_assets/{current_user.id}/uploads/{file_uuid}/{os.path.basename(request_dto.filename)}"
 

--- a/backend/tests/source_assets/test_source_asset_controller.py
+++ b/backend/tests/source_assets/test_source_asset_controller.py
@@ -51,6 +51,8 @@ def fixture_mock_service():
     service.get_all_vto_assets = AsyncMock()
     service.delete_asset = AsyncMock()
     service.get_asset_by_id = AsyncMock()
+    service.generate_signed_upload_url = AsyncMock()
+    service.finalize_direct_upload = AsyncMock()
     return service
 
 
@@ -263,3 +265,95 @@ def test_get_source_asset_not_found(client, mock_service):
     mock_service.get_asset_by_id.return_value = None
     response = client.get("/api/source_assets/999")
     assert response.status_code == 404
+
+
+def test_generate_source_asset_upload_url_success(
+    client, mock_service, mock_workspace_auth
+):
+    from src.source_assets.dto.generate_upload_url_dto import (
+        GenerateSourceAssetUploadUrlResponseDto,
+    )
+
+    mock_service.generate_signed_upload_url.return_value = (
+        GenerateSourceAssetUploadUrlResponseDto(
+            upload_url="https://signed.gcs/upload",
+            gcs_uri="gs://b/source_assets/1/uploads/uuid/test.png",
+            file_uuid="uuid-123",
+        )
+    )
+
+    payload = {
+        "workspaceId": 1,
+        "filename": "test.png",
+        "contentType": "image/png",
+        "size": 1024,
+    }
+    response = client.post(
+        "/api/source_assets/generate-upload-url", json=payload
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["uploadUrl"] == "https://signed.gcs/upload"
+    assert data["gcsUri"] == "gs://b/source_assets/1/uploads/uuid/test.png"
+    assert data["fileUuid"] == "uuid-123"
+    mock_workspace_auth.authorize.assert_called_once()
+
+
+def test_generate_source_asset_upload_url_too_large(client):
+    payload = {
+        "workspaceId": 1,
+        "filename": "huge.mp4",
+        "contentType": "video/mp4",
+        "size": 600 * 1024 * 1024,
+    }
+    response = client.post(
+        "/api/source_assets/generate-upload-url", json=payload
+    )
+    assert response.status_code == 413
+
+
+def test_generate_source_asset_upload_url_invalid_format(client):
+    payload = {
+        "workspaceId": 1,
+        "filename": "document.pdf",
+        "contentType": "application/pdf",
+        "size": 1024,
+    }
+    response = client.post(
+        "/api/source_assets/generate-upload-url", json=payload
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported file format."
+
+
+def test_finalize_source_asset_upload_success(
+    client, mock_service, mock_workspace_auth, mock_user
+):
+    mock_response = SourceAssetResponseDto(
+        id=10,
+        workspace_id=1,
+        user_id=mock_user.id,
+        gcs_uri="gs://b/source_assets/1/uploads/uuid/test.png",
+        original_filename="test.png",
+        mime_type=MimeTypeEnum.IMAGE_PNG,
+        aspect_ratio="1:1",
+        file_hash="hash123",
+        scope=AssetScopeEnum.PRIVATE,
+        asset_type=AssetTypeEnum.GENERIC_IMAGE,
+        presigned_url="https://signed.url",
+        presigned_original_url="",
+        presigned_thumbnail_url="",
+        user_email=mock_user.email,
+    )
+    mock_service.finalize_direct_upload.return_value = mock_response
+
+    payload = {
+        "workspaceId": 1,
+        "gcsUri": "gs://b/source_assets/1/uploads/uuid/test.png",
+        "filename": "test.png",
+        "mimeType": "image/png",
+        "size": 1024,
+    }
+    response = client.post("/api/source_assets/finalize-upload", json=payload)
+    assert response.status_code == 201
+    assert response.json()["id"] == 10

--- a/backend/tests/source_assets/test_source_asset_service.py
+++ b/backend/tests/source_assets/test_source_asset_service.py
@@ -679,6 +679,7 @@ async def test_finalize_direct_upload_success_image(
         FinalizeSourceAssetUploadDto,
     )
 
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
     mock_dependencies["iam_signer"].generate_presigned_url.return_value = (
         "https://signed.url"
     )
@@ -716,6 +717,7 @@ async def test_finalize_direct_upload_video_and_audio(
         FinalizeSourceAssetUploadDto,
     )
 
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
     mock_dependencies["iam_signer"].generate_presigned_url.return_value = (
         "https://signed.url"
     )
@@ -766,15 +768,17 @@ async def test_finalize_direct_upload_video_and_audio(
 
 @pytest.mark.anyio
 async def test_finalize_direct_upload_non_admin_scope_error(
-    service, sample_user
+    service, mock_dependencies, sample_user
 ):
     from src.source_assets.dto.finalize_upload_dto import (
         FinalizeSourceAssetUploadDto,
     )
 
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
+
     dto = FinalizeSourceAssetUploadDto(
         workspace_id=1,
-        gcs_uri="gs://b/file.png",
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/file.png",
         filename="file.png",
         mime_type="image/png",
         size=100,

--- a/backend/tests/source_assets/test_source_asset_service.py
+++ b/backend/tests/source_assets/test_source_asset_service.py
@@ -43,7 +43,7 @@ def fixture_mock_dependencies():
     return {
         "repo": AsyncMock(),
         "user_repo": AsyncMock(),
-        "gcs_service": MagicMock(),
+        "gcs_service": MagicMock(bucket_name="bucket"),
         "iam_signer": MagicMock(),
         "imagen_service": AsyncMock(),
         "tags_repo": AsyncMock(),
@@ -778,7 +778,7 @@ async def test_finalize_direct_upload_non_admin_scope_error(
 
     dto = FinalizeSourceAssetUploadDto(
         workspace_id=1,
-        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/file.png",
+        gcs_uri="gs://bucket/source_assets/1/file.png",
         filename="file.png",
         mime_type="image/png",
         size=100,
@@ -787,3 +787,23 @@ async def test_finalize_direct_upload_non_admin_scope_error(
     with pytest.raises(HTTPException) as exc_info:
         await service.finalize_direct_upload(dto, sample_user)
     assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_convert_to_png_heic_heif_success(service):
+    import pillow_heif
+    from fastapi import UploadFile
+
+    img = PILImage.new("RGB", (20, 20), color="green")
+    buf = io.BytesIO()
+    try:
+        img.save(buf, format="HEIF")
+    except Exception:
+        pillow_heif.from_pillow(img).save(buf, format="HEIF")
+    buf.seek(0)
+    upload_file = UploadFile(file=buf, filename="test.heic")
+    png_bytes = await service.convert_to_png(upload_file)
+    assert png_bytes is not None
+    out_img = PILImage.open(io.BytesIO(png_bytes))
+    assert out_img.format == "PNG"
+    assert out_img.size == (20, 20)

--- a/backend/tests/source_assets/test_source_asset_service.py
+++ b/backend/tests/source_assets/test_source_asset_service.py
@@ -613,3 +613,173 @@ async def test_upload_asset_upscale_failure(
     )
 
     assert response.id == 80
+
+
+@pytest.mark.anyio
+async def test_generate_signed_upload_url_success(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.generate_upload_url_dto import (
+        GenerateSourceAssetUploadUrlDto,
+    )
+
+    mock_dependencies[
+        "iam_signer"
+    ].generate_v4_upload_signed_url.return_value = (
+        "https://signed.gcs/upload",
+        "gs://bucket/source_assets/1/uploads/uuid/test.png",
+    )
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
+
+    dto = GenerateSourceAssetUploadUrlDto(
+        workspace_id=1,
+        filename="test.png",
+        content_type="image/png",
+        size=1024,
+    )
+    result = await service.generate_signed_upload_url(dto, sample_user)
+
+    assert result.upload_url == "https://signed.gcs/upload"
+    assert result.gcs_uri == "gs://bucket/source_assets/1/uploads/uuid/test.png"
+    assert result.file_uuid is not None
+
+
+@pytest.mark.anyio
+async def test_generate_signed_upload_url_error(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.generate_upload_url_dto import (
+        GenerateSourceAssetUploadUrlDto,
+    )
+
+    mock_dependencies[
+        "iam_signer"
+    ].generate_v4_upload_signed_url.return_value = (
+        None,
+        None,
+    )
+    mock_dependencies["gcs_service"].bucket_name = "bucket"
+
+    dto = GenerateSourceAssetUploadUrlDto(
+        workspace_id=1,
+        filename="test.png",
+        content_type="image/png",
+        size=1024,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await service.generate_signed_upload_url(dto, sample_user)
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.anyio
+async def test_finalize_direct_upload_success_image(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.finalize_upload_dto import (
+        FinalizeSourceAssetUploadDto,
+    )
+
+    mock_dependencies["iam_signer"].generate_presigned_url.return_value = (
+        "https://signed.url"
+    )
+
+    saved_asset = SourceAssetModel(
+        id=101,
+        workspace_id=1,
+        user_id=sample_user.id,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/image.png",
+        original_filename="image.png",
+        file_hash="hash101",
+        mime_type=MimeTypeEnum.IMAGE_PNG,
+    )
+    mock_dependencies["repo"].create.return_value = saved_asset
+
+    dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/image.png",
+        filename="image.png",
+        mime_type="image/png",
+        size=2048,
+    )
+    response = await service.finalize_direct_upload(dto, sample_user)
+
+    assert response.id == 101
+    assert response.original_filename == "image.png"
+    mock_dependencies["repo"].create.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_finalize_direct_upload_video_and_audio(
+    service, mock_dependencies, sample_user
+):
+    from src.source_assets.dto.finalize_upload_dto import (
+        FinalizeSourceAssetUploadDto,
+    )
+
+    mock_dependencies["iam_signer"].generate_presigned_url.return_value = (
+        "https://signed.url"
+    )
+
+    saved_video = SourceAssetModel(
+        id=102,
+        workspace_id=1,
+        user_id=sample_user.id,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/video.mp4",
+        original_filename="video.mp4",
+        file_hash="hash102",
+        mime_type=MimeTypeEnum.VIDEO_MP4,
+        asset_type=AssetTypeEnum.GENERIC_VIDEO,
+    )
+    mock_dependencies["repo"].create.return_value = saved_video
+
+    video_dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/video.mp4",
+        filename="video.mp4",
+        mime_type="video/mp4",
+        size=50000,
+    )
+    res_video = await service.finalize_direct_upload(video_dto, sample_user)
+    assert res_video.id == 102
+
+    saved_audio = SourceAssetModel(
+        id=103,
+        workspace_id=1,
+        user_id=sample_user.id,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/audio.mp3",
+        original_filename="audio.mp3",
+        file_hash="hash103",
+        mime_type=MimeTypeEnum.AUDIO_MPEG,
+    )
+    mock_dependencies["repo"].create.return_value = saved_audio
+
+    audio_dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://bucket/source_assets/1/uploads/uuid/audio.mp3",
+        filename="audio.mp3",
+        mime_type="audio/mp3",
+        size=30000,
+    )
+    res_audio = await service.finalize_direct_upload(audio_dto, sample_user)
+    assert res_audio.id == 103
+
+
+@pytest.mark.anyio
+async def test_finalize_direct_upload_non_admin_scope_error(
+    service, sample_user
+):
+    from src.source_assets.dto.finalize_upload_dto import (
+        FinalizeSourceAssetUploadDto,
+    )
+
+    dto = FinalizeSourceAssetUploadDto(
+        workspace_id=1,
+        gcs_uri="gs://b/file.png",
+        filename="file.png",
+        mime_type="image/png",
+        size=100,
+        scope=AssetScopeEnum.SYSTEM,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await service.finalize_direct_upload(dto, sample_user)
+    assert exc_info.value.status_code == 403

--- a/backend/tests/source_assets/test_source_asset_service.py
+++ b/backend/tests/source_assets/test_source_asset_service.py
@@ -360,6 +360,8 @@ async def test_get_all_vto_assets(service, mock_dependencies, sample_user):
 async def test_convert_to_png_success(service):
     # Setup mock UploadFile
     mock_file = AsyncMock()
+    mock_file.filename = "image.png"
+    mock_file.content_type = "image/png"
     mock_file.read.return_value = get_dummy_image_bytes()
 
     png_bytes = await service.convert_to_png(mock_file)
@@ -790,18 +792,38 @@ async def test_finalize_direct_upload_non_admin_scope_error(
 
 
 @pytest.mark.anyio
-async def test_convert_to_png_heic_heif_success(service):
-    import pillow_heif
+async def test_convert_to_png_heic_heif_success(service, monkeypatch):
     from fastapi import UploadFile
 
-    img = PILImage.new("RGB", (20, 20), color="green")
-    buf = io.BytesIO()
-    try:
-        img.save(buf, format="HEIF")
-    except Exception:
-        pillow_heif.from_pillow(img).save(buf, format="HEIF")
-    buf.seek(0)
+    class MockHEIC2PNG:
+        def __init__(self, path, quality=None, overwrite=False):
+            self.path = path
+            self.overwrite = overwrite
+
+        def save(self, output_path):
+            img = PILImage.new("RGB", (20, 20), color="green")
+            img.save(output_path, format="PNG")
+
+    monkeypatch.setattr("heic2png.HEIC2PNG", MockHEIC2PNG)
+
+    buf = io.BytesIO(b"fake_heic_bytes")
     upload_file = UploadFile(file=buf, filename="test.heic")
+    png_bytes = await service.convert_to_png(upload_file)
+    assert png_bytes is not None
+    out_img = PILImage.open(io.BytesIO(png_bytes))
+    assert out_img.format == "PNG"
+    assert out_img.size == (20, 20)
+
+
+@pytest.mark.anyio
+async def test_convert_to_png_standard_image_success(service):
+    from fastapi import UploadFile
+
+    img = PILImage.new("RGB", (20, 20), color="blue")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    buf.seek(0)
+    upload_file = UploadFile(file=buf, filename="test.jpg")
     png_bytes = await service.convert_to_png(upload_file)
     assert png_bytes is not None
     out_img = PILImage.open(io.BytesIO(png_bytes))

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -646,6 +646,7 @@ dependencies = [
     { name = "mediapy" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pillow-heif" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -699,6 +700,7 @@ requires-dist = [
     { name = "mediapy", specifier = ">=1.2.4" },
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "pandas", specifier = ">=2.3.3" },
+    { name = "pillow-heif", specifier = ">=0.18.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.10" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pypdf", specifier = ">=6.1.1" },
@@ -2488,6 +2490,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/2f/16cabcc6426c32218ace36bf0d55955e813f2958afddbf1d391849fee9d1/pillow-12.0.0-cp314-cp314t-win32.whl", hash = "sha256:3830c769decf88f1289680a59d4f4c46c72573446352e2befec9a8512104fa52", size = 6408045, upload-time = "2025-10-15T18:23:53.177Z" },
     { url = "https://files.pythonhosted.org/packages/35/73/e29aa0c9c666cf787628d3f0dcf379f4791fba79f4936d02f8b37165bdf8/pillow-12.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:905b0365b210c73afb0ebe9101a32572152dfd1c144c7e28968a331b9217b94a", size = 7148282, upload-time = "2025-10-15T18:23:55.316Z" },
     { url = "https://files.pythonhosted.org/packages/c1/70/6b41bdcddf541b437bbb9f47f94d2db5d9ddef6c37ccab8c9107743748a4/pillow-12.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:99353a06902c2e43b43e8ff74ee65a7d90307d82370604746738a1e0661ccca7", size = 2525630, upload-time = "2025-10-15T18:23:57.149Z" },
+]
+
+[[package]]
+name = "pillow-heif"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/5f/4753689400e657ca5d984f5e897657dab12d91b62f1bb6a1e73487b59a97/pillow_heif-1.4.0.tar.gz", hash = "sha256:55a7c0cb5321538d1ca74037be54b48d147017735a766eb29bcca4761253a1f1", size = 17127538, upload-time = "2026-06-10T16:02:40.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ba/1a8f5a42c14cf8ad7c7a6b459de33e2bbd693a15690802463b370ee578cd/pillow_heif-1.4.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:5c6181fb25c7d28f98702160b98967d1d7d432d71decac9351f5a47ee33554e0", size = 4730173, upload-time = "2026-06-10T16:01:23.282Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/64/e659dd4a9b54ad148b8e753df6c9b84e0140065bebb69665b583b53804a8/pillow_heif-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ade286eeadb361773604e294f98c4a1b64b577aca271faa6971e2fbd018918c7", size = 3955563, upload-time = "2026-06-10T16:01:24.75Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/48/73336f6b4c6532ca98025a8c1a0254882d52c93ce7cc377440234fa20317/pillow_heif-1.4.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:972c68fae8379c158aad222defa8b8f10c858a5f7f9cc99942f34b9667a516cd", size = 6249338, upload-time = "2026-06-10T16:01:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7a/e8053fa5e31f5f330ad1e9eec77625ba7ce97a1e765e5e05c85bf65d574a/pillow_heif-1.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfcd611a09dbb949715d5f25063bd3668e0daa06b53a3ed5bbd92d36b4f6b2a9", size = 5664216, upload-time = "2026-06-10T16:01:29.074Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e8/76f6ab993238c9d7da53fb64e588fd37ef7b603895b2383f1cbccc209233/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08026afd5f90628e029fe88aaa222280428ba7cc485a7cae553e78f7bb289b74", size = 7336120, upload-time = "2026-06-10T16:01:30.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/45/d77ad6de495dfcc55be00a48434183abd7cf8e3416916236e29d0ecd95b6/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8d001996e3a4687551385c2fe4d3fb84293727052fca1c0f50528c78b8327c7", size = 6597816, upload-time = "2026-06-10T16:01:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/f240ce0e84a6d0cf8dfee1834b4aec29f209c08e3d2047196cee65527fb7/pillow_heif-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:107d598a1b1694ba6f371927ffd6d72d6f9af2ca4082577d9edbfdeed465f940", size = 6514536, upload-time = "2026-06-10T16:01:34.571Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d4/d15e568b61f6020b1a772174b5c9c60341a1f0130951c518d33461b36bf8/pillow_heif-1.4.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:c699f8a3e845839bba590d3459ce59dba16c82c38e799955bef7042c54443eba", size = 4730166, upload-time = "2026-06-10T16:01:36.594Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c0/e4d9b5570ee70f12c817722df398cdcba7fb25f4ddc691a79008a31c653d/pillow_heif-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8f90b500ec1ae3a59d6613fd96123de35457f69fb9b3cd314d4b5a6799ba9843", size = 3955577, upload-time = "2026-06-10T16:01:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/17/75/717a3ac5edf3b5c027659c59bbd09f731708e76eab03a7bcd89d68edefd7/pillow_heif-1.4.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6d907f454afa1958a688902e53f50ed7a98c8cbd6261d20f84b15e25f068020", size = 6249393, upload-time = "2026-06-10T16:01:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ba/9d1336b1c5a6d2b7098cc851fcd3dbb5f25e37f942f327a404b2c8e0205d/pillow_heif-1.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be955358e501ab03cd83331a49d331c16b8ea1a4f5751d46c24e6b28d8aa6a56", size = 5664268, upload-time = "2026-06-10T16:01:42.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/8382df95a9b20d295742f19a54fc8f66c438362b841c416786b4f9a5c3e1/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1207b6b0819654262811a0cb74730cca1ced1ab7786a0fcd92f55b84ca07a05c", size = 7336108, upload-time = "2026-06-10T16:01:44.682Z" },
+    { url = "https://files.pythonhosted.org/packages/da/72/fbcbfac3ee43f8da79b1c6a8cbd62c2b9ee49ae069548029715c5a3fdc55/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cdd3ebd552b50d0221bf525e033fbe3e83130b05c81bfd53d50ed4eafbb77a7c", size = 6597858, upload-time = "2026-06-10T16:01:46.501Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4b/3250c23b53f3ae0b39000da6bc517f2762600516f1d44549c9eb65657587/pillow_heif-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:19a2d9bd52b1f6dabed5305b8b5c4962b2bf7c21e8195c909e9425e4ca8ebf72", size = 6514532, upload-time = "2026-06-10T16:01:48.646Z" },
+    { url = "https://files.pythonhosted.org/packages/44/bf/2d210965f010ed3e88c03530137ce03aeb9e1e1306e5815b49d0d3b9e2f0/pillow_heif-1.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4849dfceeec19d12c819bd12e138f91f1aa181eb2fd21231644bda91d2d0b292", size = 4730182, upload-time = "2026-06-10T16:01:50.45Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d3/64818f50ff63066c2fbbbd2eecef7acd774bc96a9ac9b672df9175cb0ecb/pillow_heif-1.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d9d05477d67b3d63d601254ddca6b1e1943b0f5e5934cb5ed123c9b89e0fc60d", size = 3955616, upload-time = "2026-06-10T16:01:52.593Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d2/ae19025e45149a7b974a4bfcf6a522b3359c7ae8afb48cce57204a0d7be9/pillow_heif-1.4.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93de4bdb496c5f509911b57b057c16ec1ed10f3617b87f03f7f152745758691b", size = 6249592, upload-time = "2026-06-10T16:02:07.409Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9b/431f3080133849ee3d2a497b4097238ba9786ba64e30820563f07c8c9a18/pillow_heif-1.4.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6789fc4fe9ffa7beafcf0e287ea355de3a3c0c84e3adfabbbfdf8b46b83f223a", size = 5664277, upload-time = "2026-06-10T16:02:09.347Z" },
+    { url = "https://files.pythonhosted.org/packages/30/bb/2e8578747987dd4c0d3289ca9ae8d9669c55cc5055bb0ccf39191b6b0338/pillow_heif-1.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31a152471c757eb02b71c9944a5973b818a21dea7980bfc57fe13945d051326", size = 7336225, upload-time = "2026-06-10T16:02:11.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/d6ddf033215a7d4b5a2ddcac423d6243bb13aae021d856028e6205ea62f1/pillow_heif-1.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a3debca82964ba4080277620601f274a8c9d509d52fd3e1faacb314dc0678ee4", size = 6597937, upload-time = "2026-06-10T16:02:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6c/170e91115a5825b646fcb40cae9cd0c8977482588f667ad22981dc0ebe4c/pillow_heif-1.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:4bd30446e025e682ac1450446e0b9a9a06efc27b5417c81b18d26aa40b97cd70", size = 6698362, upload-time = "2026-06-10T16:02:15.48Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6c/b7e21b57479a159157e944da641dc2112b432c4ef421c43c02a9c87580a8/pillow_heif-1.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9299b4e6cfa3d49c0495680011d224db69e41687c0e2de81a38ea6c39276e15b", size = 4731147, upload-time = "2026-06-10T16:02:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/efb46f9f7c4a152ad1db194388f490b5c13f5fd11132aef99ba6c4e57e60/pillow_heif-1.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6b772360a412df897ed59d56d2ef30d52b6cce7c3f7b8b170a9578deb311953b", size = 3956423, upload-time = "2026-06-10T16:02:18.797Z" },
+    { url = "https://files.pythonhosted.org/packages/56/1d/077278664d25759957ed2d16e2a777a0ecaf3629059bea4e5fc796e4e9db/pillow_heif-1.4.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffbed970ea96485f96874604d3df298c06e89475dea09c217b8b901cc7ed7d1a", size = 6254712, upload-time = "2026-06-10T16:02:20.454Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1f/20f28434f4ea119c34c98d3f3b3950236471a5cf5c5c8d47b400d1bfa2b2/pillow_heif-1.4.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f75faab30c0b1f20d266e0c8a1a746f7aa56694baf3fd5cc4d86f2f242bb58de", size = 5668435, upload-time = "2026-06-10T16:02:22.391Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/39/79a1e3b3d8a09fc618f5ecb984170d716b812fba7342f3246524a9c829e7/pillow_heif-1.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:500bc4ea048ed8f2e7167451737539c2763c2d157357d1706024b2a9e6910c61", size = 7341339, upload-time = "2026-06-10T16:02:24.566Z" },
+    { url = "https://files.pythonhosted.org/packages/95/52/e72d34251e4712e4591b245aa3888beaee750894c6f7777d7505695ee364/pillow_heif-1.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:387b16e826ec29ab31101f257f362ed33e9b6aecec77d4f7d19caeb33fed0f1a", size = 6602011, upload-time = "2026-06-10T16:02:26.426Z" },
+    { url = "https://files.pythonhosted.org/packages/68/36/03647089e0dc9ccdeb0de2653b549ff83c414fa0a5799d56b994b1894a0e/pillow_heif-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:84f138c31d34a8bab5ffa07ffbcf9b865b8ad34e6c495dcb6e01fb29574e218d", size = 6698960, upload-time = "2026-06-10T16:02:28.198Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -642,11 +642,11 @@ dependencies = [
     { name = "google-cloud-workflows" },
     { name = "google-genai" },
     { name = "gunicorn" },
+    { name = "heic2png" },
     { name = "httpx" },
     { name = "mediapy" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pillow-heif" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -696,11 +696,11 @@ requires-dist = [
     { name = "google-cloud-workflows", specifier = ">=1.19.0" },
     { name = "google-genai", specifier = ">=1.52.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "heic2png", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mediapy", specifier = ">=1.2.4" },
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "pillow-heif", specifier = ">=0.18.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.10" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pypdf", specifier = ">=6.1.1" },
@@ -1670,6 +1670,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "heic2png"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pillow-heif" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/2a/0bc5c742368a15ae8469af742ac2b6a01739b5c58468a2662781d639925e/heic2png-1.2.0.tar.gz", hash = "sha256:2c95313b99fcd45aed3b5b5e6b48137e86d68d30d288fef575480fa587e4604b", size = 11604, upload-time = "2025-09-23T08:38:37.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/72/3184fbc08287199f0530c790fe29fc6e111a1516db80f2d530300ca196cd/heic2png-1.2.0-py3-none-any.whl", hash = "sha256:32e9ce0c1349bdbd435d69b6626063962be73fb9b39fed2c562d8ef8a55f1f57", size = 9603, upload-time = "2025-09-23T08:38:36.123Z" },
 ]
 
 [[package]]

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -53,3 +53,4 @@
     </div>
   </div>
 </div>
+<app-upload-progress-widget/>

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
+import {of} from 'rxjs';
 import {AppComponent} from './app.component';
 import {LoadingService} from './common/services/loading.service';
-import {of} from 'rxjs';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {MediaUploadService} from './common/services/media-upload/media-upload.service';
 
 describe('AppComponent', () => {
-  let loadingServiceMock: any;
+  let loadingServiceMock: unknown;
 
   beforeEach(async () => {
     loadingServiceMock = {
@@ -30,9 +32,12 @@ describe('AppComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, HttpClientTestingModule],
       declarations: [AppComponent],
-      providers: [{provide: LoadingService, useValue: loadingServiceMock}],
+      providers: [
+        {provide: LoadingService, useValue: loadingServiceMock},
+        MediaUploadService,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -36,7 +36,7 @@ describe('AppComponent', () => {
       declarations: [AppComponent],
       providers: [
         {provide: LoadingService, useValue: loadingServiceMock},
-        MediaUploadService,
+        {provide: MediaUploadService, useValue: {inProgressCount: () => 0}},
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -18,6 +18,7 @@ import {Component} from '@angular/core';
 import {Router, NavigationEnd, Event as NavigationEvent} from '@angular/router';
 import {trigger, transition, style, query, animate} from '@angular/animations';
 import {LoadingService} from './common/services/loading.service';
+import {MediaUploadService} from './common/services/media-upload/media-upload.service';
 
 @Component({
   selector: 'app-root',
@@ -57,6 +58,7 @@ export class AppComponent {
   constructor(
     private router: Router,
     public loadingService: LoadingService,
+    public uploadService: MediaUploadService,
   ) {
     this.router.events.subscribe((event: NavigationEvent) => {
       if (event instanceof NavigationEnd) {

--- a/frontend/src/app/auth.interceptor.ts
+++ b/frontend/src/app/auth.interceptor.ts
@@ -35,6 +35,15 @@ export class AuthInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>,
     next: HttpHandler,
   ): Observable<HttpEvent<unknown>> {
+    const isBackendUrl =
+      request.url.startsWith('/') ||
+      (environment.backendURL.startsWith('http') &&
+        request.url.startsWith(environment.backendURL));
+    // Add validation for not intercepting the Google account url
+    if (!isBackendUrl) {
+      return next.handle(request);
+    }
+
     // Asynchronously get a valid token. This will use the cache or trigger a silent refresh.
     return this.authService.getValidIdentityPlatformToken$().pipe(
       switchMap(token => {

--- a/frontend/src/app/common/components/gallery-card/gallery-card.component.html
+++ b/frontend/src/app/common/components/gallery-card/gallery-card.component.html
@@ -67,16 +67,31 @@
 
       <!-- Show thumbnail by default -->
       <ng-container *ngIf="hoveredVideoId !== item.id">
-        <img
-          *ngFor="let url of displayUrls; let i = index"
-          class="media-element"
-          loading="lazy"
-          [src]="url"
-          [alt]="getShortPrompt(item.prompt)"
-          [class.active]="currentImageIndex === i"
-          [class.inactive]="currentImageIndex !== i"
-          (load)="onMediaLoad(i)"
-        />
+        <ng-container *ngIf="hasThumbnail">
+          <img
+            *ngFor="let url of item.presignedThumbnailUrls; let i = index"
+            class="media-element"
+            loading="lazy"
+            [src]="url"
+            [alt]="getShortPrompt(item.prompt)"
+            [class.active]="currentImageIndex === i"
+            [class.inactive]="currentImageIndex !== i"
+            (load)="onMediaLoad(i)"
+          />
+        </ng-container>
+        <ng-container *ngIf="!hasThumbnail">
+          <video
+            *ngFor="let url of item.presignedUrls; let i = index"
+            class="media-element"
+            [class.active]="currentImageIndex === i"
+            [class.inactive]="currentImageIndex !== i"
+            preload="metadata"
+            muted
+            playsinline
+          >
+            <source [src]="url" [type]="item.mimeType" />
+          </video>
+        </ng-container>
         <!-- Play Button Overlay -->
         <div class="video-play-overlay">
           <svg

--- a/frontend/src/app/common/components/gallery-card/gallery-card.component.ts
+++ b/frontend/src/app/common/components/gallery-card/gallery-card.component.ts
@@ -80,6 +80,13 @@ export class GalleryCardComponent implements OnDestroy {
     return this.item.presignedUrls || [];
   }
 
+  get hasThumbnail(): boolean {
+    return (
+      !!this.item.presignedThumbnailUrls &&
+      this.item.presignedThumbnailUrls.length > 0
+    );
+  }
+
   get displayPaddingBottom(): string {
     const rawRatio =
       this.item.aspectRatio ||

--- a/frontend/src/app/common/components/studio-button/studio-button.component.html
+++ b/frontend/src/app/common/components/studio-button/studio-button.component.html
@@ -23,7 +23,7 @@
   [class.btn-medium]="size === 'medium'"
   [class.btn-large]="size === 'large'"
   [disabled]="disabled"
+  (click)="handleHostClick($event)"
 >
-
   <ng-content></ng-content>
 </button>

--- a/frontend/src/app/common/components/studio-button/studio-button.component.scss
+++ b/frontend/src/app/common/components/studio-button/studio-button.component.scss
@@ -187,6 +187,14 @@
   }
 }
 
+.btn-glass-primary ::ng-deep mat-icon,
+.btn-cta ::ng-deep mat-icon {
+  font-size: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 // Circular variant for "Edit" button (primary glass but round)
 .btn-glass-circle {
   @extend .btn-glass-primary;

--- a/frontend/src/app/common/components/studio-button/studio-button.component.ts
+++ b/frontend/src/app/common/components/studio-button/studio-button.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Component, Input} from '@angular/core';
+import {Component, HostBinding, Input} from '@angular/core';
 
 @Component({
   selector: 'studio-button',
@@ -26,4 +26,18 @@ export class StudioButtonComponent {
   @Input() shape: 'pill' | 'circle' = 'pill';
   @Input() size: 'small' | 'medium' | 'large' | 'none' = 'none';
   @Input() disabled = false;
+
+  @HostBinding('style.pointer-events')
+  get pointerEvents(): string {
+    return this.disabled ? 'none' : 'auto';
+  }
+
+  handleHostClick(event: MouseEvent): void {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      return;
+    }
+  }
 }

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
@@ -1,0 +1,257 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div
+  *ngIf="!isLoginRoute() && uploadService.hasActiveOrFinishedUploads()"
+  id="upload-progress-widget"
+  class="upload-widget-container"
+  [class.minimized]="!isExpanded()"
+>
+  <div
+    *ngIf="!isExpanded()"
+    id="upload-widget-minimized"
+    class="minimized-pill"
+  >
+    <ng-container *ngTemplateOutlet="uploadWidgetHeader"></ng-container>
+  </div>
+
+  <!-- MAXIMIZED DETAILED PANEL MODE -->
+  <div
+    *ngIf="isExpanded()"
+    id="upload-widget-maximized"
+    class="maximized-panel"
+  >
+    <!-- HEADER -->
+    <div class="panel-header">
+      <ng-container *ngTemplateOutlet="uploadWidgetHeader"></ng-container>
+    </div>
+
+    <!-- OVERALL PROGRESS BAR -->
+    <div
+      *ngIf="uploadService.inProgressCount() > 0"
+      class="overall-progress-track"
+    >
+      <div
+        class="overall-progress-fill"
+        [style.width.%]="uploadService.overallProgress()"
+      ></div>
+    </div>
+
+    <!-- FILE LIST -->
+    <div id="upload-widget-file-list" class="file-list">
+      <div
+        *ngFor="let item of uploadService.uploadQueue()"
+        [id]="'upload-item-' + item.id"
+        class="file-item-row"
+        [class.item-failed]="item.status === UploadStatus.FAILED"
+        [class.item-completed]="item.status === UploadStatus.COMPLETED"
+        [class.item-cancelled]="item.status === UploadStatus.CANCELLED"
+      >
+        <!-- FILE ICON & RETRY/CANCEL ACTION -->
+        <div class="item-icon-wrapper">
+          <mat-icon class="file-type-icon">{{
+            getFileIcon(item.mimeType)
+          }}</mat-icon>
+          <button
+            *ngIf="item.status === UploadStatus.FAILED || item.status === UploadStatus.CANCELLED"
+            [id]="'retry-btn-' + item.id"
+            class="retry-item-btn"
+            type="button"
+            title="Retry uploading file"
+            (click)="onRetryItem(item.id)"
+          >
+            <mat-icon>refresh</mat-icon>
+          </button>
+          <button
+            *ngIf="
+              item.status === UploadStatus.QUEUED ||
+              item.status === UploadStatus.GENERATING_URL ||
+              item.status === UploadStatus.UPLOADING ||
+              item.status === UploadStatus.FINALIZING
+            "
+            [id]="'cancel-btn-' + item.id"
+            class="cancel-item-btn"
+            type="button"
+            title="Cancel upload"
+            (click)="onCancelItem(item.id)"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+
+        <!-- DETAILS -->
+        <div class="item-details">
+          <div class="item-meta">
+            <span class="item-filename" [title]="item.filename">{{
+              item.filename
+            }}</span>
+            <span class="item-size">{{ formatFileSize(item.size) }}</span>
+          </div>
+
+          <!-- STATUS SPECIFIC RENDERING -->
+          <div class="item-status-container">
+            <!-- QUEUED -->
+            <div
+              *ngIf="item.status === UploadStatus.QUEUED"
+              class="status-badge status-queued"
+            >
+              <mat-icon class="badge-icon">schedule</mat-icon>
+              <span>Waiting in queue (Max 5 concurrent)</span>
+            </div>
+
+            <!-- GENERATING URL -->
+            <div
+              *ngIf="item.status === UploadStatus.GENERATING_URL"
+              class="status-badge status-preparing"
+            >
+              <mat-spinner diameter="14" strokeWidth="2"></mat-spinner>
+              <span>Preparing signed URL</span>
+            </div>
+
+            <!-- UPLOADING -->
+            <div
+              *ngIf="item.status === UploadStatus.UPLOADING"
+              class="status-uploading"
+            >
+              <div class="progress-bar-track">
+                <div
+                  class="progress-bar-fill"
+                  [style.width.%]="item.progress"
+                ></div>
+              </div>
+              <span class="progress-pct-text">{{ item.progress }}%</span>
+            </div>
+
+            <!-- FINALIZING -->
+            <div
+              *ngIf="item.status === UploadStatus.FINALIZING"
+              class="status-badge status-finalizing"
+            >
+              <mat-spinner diameter="14" strokeWidth="2"></mat-spinner>
+              <span>Finalizing asset</span>
+            </div>
+
+            <!-- COMPLETED -->
+            <div
+              *ngIf="item.status === UploadStatus.COMPLETED"
+              class="status-badge status-completed"
+            >
+              <mat-icon class="badge-icon">check_circle</mat-icon>
+              <span>Uploaded successfully</span>
+            </div>
+
+            <!-- FAILED -->
+            <div
+              *ngIf="item.status === UploadStatus.FAILED"
+              class="status-badge status-failed"
+            >
+              <mat-icon class="badge-icon">error</mat-icon>
+              <span class="error-msg">{{
+                item.errorMessage || 'Upload failed'
+              }}</span>
+            </div>
+
+            <!-- CANCELLED -->
+            <div
+              *ngIf="item.status === UploadStatus.CANCELLED"
+              class="status-badge status-cancelled"
+            >
+              <mat-icon class="badge-icon">cancel</mat-icon>
+              <span>Upload cancelled</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- FOOTER ACTION FOR ALL FAILED -->
+    <div class="panel-footer">
+      <button
+        id="retry-all-failed-btn"
+        class="retry-all-btn"
+        type="button"
+        [disabled]="uploadService.totalFailed() === 0 || !uploadService.canClose()"
+        (click)="onRetryAll()"
+      >
+        <mat-icon>refresh</mat-icon>
+        <span>Retry All Failed</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<ng-template #uploadWidgetHeader>
+  <div class="pill-left">
+    <span class="pill-title"
+      >Uploads: {{ uploadService.overallProgress() }}%</span
+    >
+  </div>
+
+  <div class="pill-badges">
+    <span
+      *ngIf="uploadService.totalUploaded() > 0"
+      class="indicator-item indicator-success"
+      [attr.title]="'Successful uploads: ' + uploadService.totalUploaded()"
+    >
+      <mat-icon class="indicator-icon">check_circle</mat-icon>
+      <span>{{ uploadService.totalUploaded() }}</span>
+    </span>
+    <span
+      *ngIf="uploadService.totalFailed() > 0"
+      class="indicator-item indicator-error"
+      [attr.title]="'Failed uploads: ' + uploadService.totalFailed()"
+    >
+      <mat-icon class="indicator-icon">warning</mat-icon>
+      <span>{{ uploadService.totalFailed() }}</span>
+    </span>
+    <span
+      *ngIf="uploadService.totalCancelled() > 0"
+      class="indicator-item indicator-cancelled"
+      [attr.title]="'Cancelled uploads: ' + uploadService.totalCancelled()"
+    >
+      <mat-icon class="indicator-icon">cancel</mat-icon>
+      <span>{{ uploadService.totalCancelled() }}</span>
+    </span>
+  </div>
+
+  <div class="pill-actions">
+    <button
+      id="upload-widget-expand-btn"
+      class="icon-btn"
+      type="button"
+      [title]="
+        isExpanded() ? 'Minimize panel' : 'Expand upload progress panel'
+      "
+      (click)="toggleExpand()"
+    >
+      <mat-icon>{{ isExpanded() ? 'expand_more' : 'expand_less' }}</mat-icon>
+    </button>
+    <button
+      id="upload-widget-min-close-btn"
+      class="icon-btn close-btn"
+      type="button"
+      [disabled]="!uploadService.canClose()"
+      [attr.title]="
+        uploadService.canClose()
+          ? 'Clear upload list'
+          : 'Uploads in progress'
+      "
+      (click)="onClose()"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+</ng-template>

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
@@ -78,6 +78,7 @@
           <button
             *ngIf="
               item.status === UploadStatus.QUEUED ||
+              item.status === UploadStatus.PREPROCESSING_FILE ||
               item.status === UploadStatus.GENERATING_URL ||
               item.status === UploadStatus.UPLOADING ||
               item.status === UploadStatus.FINALIZING
@@ -95,8 +96,8 @@
         <!-- DETAILS -->
         <div class="item-details">
           <div class="item-meta">
-            <span class="item-filename" [title]="item.filename">{{
-              item.filename
+            <span class="item-filename" [title]="item.originalFilename">{{
+              item.originalFilename
             }}</span>
             <span class="item-size">{{ formatFileSize(item.size) }}</span>
           </div>
@@ -109,7 +110,7 @@
               class="status-badge status-queued"
             >
               <mat-icon class="badge-icon">schedule</mat-icon>
-              <span>Waiting in queue (Max 5 concurrent)</span>
+              <span>Waiting in queue</span>
             </div>
 
             <!-- GENERATING URL -->
@@ -119,6 +120,15 @@
             >
               <mat-spinner diameter="14" strokeWidth="2"></mat-spinner>
               <span>Preparing signed URL</span>
+            </div>
+
+            <!-- PREPROCESSING FILE -->
+            <div
+              *ngIf="item.status === UploadStatus.PREPROCESSING_FILE"
+              class="status-badge status-preparing"
+            >
+              <mat-spinner diameter="14" strokeWidth="2"></mat-spinner>
+              <span>Preprocessing file</span>
             </div>
 
             <!-- UPLOADING -->
@@ -159,9 +169,11 @@
               class="status-badge status-failed"
             >
               <mat-icon class="badge-icon">error</mat-icon>
-              <span class="error-msg">{{
-                item.errorMessage || 'Upload failed'
-              }}</span>
+              <span class="error-msg" [title]="item.errorMessage || 'Upload failed'">
+                {{
+                  item.errorMessage || 'Upload failed'
+                }}
+              </span>
             </div>
 
             <!-- CANCELLED -->

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
@@ -70,10 +70,12 @@
             [id]="'retry-btn-' + item.id"
             class="retry-item-btn"
             type="button"
-            title="Retry uploading file"
+            [disabled]="!item.file"
+            [class.!cursor-not-allowed]="!item.file"
+            [attr.title]="item.file ? 'Retry uploading file' : 'File binary payload missing from memory. Please re-upload from your device.'"
             (click)="onRetryItem(item.id)"
           >
-            <mat-icon>refresh</mat-icon>
+            <mat-icon [style.opacity]="item.file ? 1 : 0.5">refresh</mat-icon>
           </button>
           <button
             *ngIf="

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.html
@@ -179,16 +179,15 @@
 
     <!-- FOOTER ACTION FOR ALL FAILED -->
     <div class="panel-footer">
-      <button
+      <studio-button
         id="retry-all-failed-btn"
-        class="retry-all-btn"
         type="button"
         [disabled]="uploadService.totalFailed() === 0 || !uploadService.canClose()"
         (click)="onRetryAll()"
       >
         <mat-icon>refresh</mat-icon>
         <span>Retry All Failed</span>
-      </button>
+      </studio-button>
     </div>
   </div>
 </div>

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
@@ -28,7 +28,6 @@
     align-items: center;
     gap: 12px;
     padding: 10px 16px;
-    background: rgba(20, 24, 33, 0.92);
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -65,11 +64,18 @@
     }
   }
 
+  .minimized-pill,
+  .maximized-panel {
+    background: radial-gradient(
+        ellipse 100% 100% at 50% 0%,
+        #4D4D4D 0%,
+        #161616 100%);
+  }
+
   /* MAXIMIZED DETAILED PANEL MODE */
   .maximized-panel {
     width: 380px;
     max-width: calc(100vw - 32px);
-    background: rgba(18, 22, 31, 0.94);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
     border: 1px solid rgba(255, 255, 255, 0.14);
@@ -368,40 +374,6 @@
       border-top: 1px solid rgba(255, 255, 255, 0.08);
       display: flex;
       justify-content: flex-end;
-
-      .retry-all-btn {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-        color: #ffffff;
-        border: none;
-        padding: 6px 12px;
-        border-radius: 8px;
-        font-size: 12px;
-        font-weight: 600;
-        cursor: pointer;
-        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
-        transition: all 0.2s ease;
-
-        &:hover {
-          background: linear-gradient(135deg, #f87171 0%, #ef4444 100%);
-          box-shadow: 0 6px 16px rgba(239, 68, 68, 0.45);
-        }
-
-        &:disabled {
-          background: rgba(255, 255, 255, 0.08);
-          color: rgba(255, 255, 255, 0.35);
-          box-shadow: none;
-          pointer-events: none;
-        }
-
-        mat-icon {
-          font-size: 16px;
-          width: 16px;
-          height: 16px;
-        }
-      }
     }
   }
 

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
@@ -1,0 +1,472 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.upload-widget-container {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 2000;
+  color: #f1f5f9;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* MINIMIZED PILL MODE */
+  .minimized-pill {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: rgba(20, 24, 33, 0.92);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 9999px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5), 0 0 1px rgba(255, 255, 255, 0.2);
+
+    &:hover {
+      background: rgba(28, 34, 46, 0.95);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    .pill-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      .pill-title {
+        font-weight: 500;
+        font-size: 13px;
+        color: #e2e8f0;
+      }
+    }
+
+    .pill-badges {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .pill-actions {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+  }
+
+  /* MAXIMIZED DETAILED PANEL MODE */
+  .maximized-panel {
+    width: 380px;
+    max-width: calc(100vw - 32px);
+    background: rgba(18, 22, 31, 0.94);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 16px;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.6), 0 0 2px rgba(255, 255, 255, 0.25);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 16px;
+      background: rgba(255, 255, 255, 0.03);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+      .header-title,
+      .pill-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        font-size: 14px;
+        color: #f8fafc;
+
+        .pill-title {
+          font-weight: 600;
+          font-size: 14px;
+          color: #f8fafc;
+        }
+
+        .header-icon {
+          color: #00e5ff;
+          font-size: 20px;
+          width: 20px;
+          height: 20px;
+        }
+
+        .progress-badge {
+          font-size: 11px;
+          font-weight: 700;
+          color: #00e5ff;
+          background: rgba(0, 229, 255, 0.12);
+          padding: 2px 8px;
+          border-radius: 12px;
+          border: none;
+        }
+      }
+
+      .header-badges,
+      .pill-badges {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .header-actions,
+      .pill-actions {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+    }
+
+    .overall-progress-track {
+      height: 3px;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.08);
+
+      .overall-progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #00e5ff 0%, #00e676 100%);
+        transition: width 0.3s ease-out;
+      }
+    }
+
+    .file-list {
+      max-height: 260px;
+      overflow-y: auto;
+      padding: 4px 12px;
+      display: flex;
+      flex-direction: column;
+
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+      &::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 3px;
+      }
+
+      .file-item-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 10px 4px;
+        background: transparent;
+        border: none;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        transition: background 0.2s ease;
+
+        &.item-cancelled {
+          background: rgba(255, 255, 255, 0.01);
+        }
+
+        &:last-child {
+          border-bottom: none;
+        }
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.03);
+        }
+
+        .item-icon-wrapper {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 6px;
+          padding-top: 2px;
+          min-width: 24px;
+
+          .file-type-icon {
+            color: #94a3b8;
+            font-size: 20px;
+            width: 20px;
+            height: 20px;
+          }
+
+          .retry-item-btn {
+            background: rgba(255, 82, 82, 0.15);
+            color: #ff5252;
+            border: 1px solid rgba(255, 82, 82, 0.3);
+            border-radius: 4px;
+            padding: 2px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s ease;
+
+            &:hover {
+              background: rgba(255, 82, 82, 0.3);
+              color: #ffffff;
+            }
+
+            mat-icon {
+              font-size: 14px;
+              width: 14px;
+              height: 14px;
+            }
+          }
+
+          .cancel-item-btn {
+            background: rgba(255, 255, 255, 0.08);
+            color: #94a3b8;
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 4px;
+            padding: 2px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s ease;
+
+            &:hover {
+              background: rgba(239, 68, 68, 0.15);
+              color: #ef4444;
+              border-color: rgba(239, 68, 68, 0.3);
+            }
+
+            mat-icon {
+              font-size: 14px;
+              width: 14px;
+              height: 14px;
+            }
+          }
+        }
+
+        .item-details {
+          flex: 1;
+          min-width: 0;
+
+          .item-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 4px;
+
+            .item-filename {
+              font-weight: 500;
+              font-size: 13px;
+              color: #f1f5f9;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            }
+
+            .item-size {
+              font-size: 11px;
+              color: #64748b;
+              white-space: nowrap;
+            }
+          }
+
+          .item-status-container {
+            font-size: 11px;
+
+            .status-badge {
+              display: flex;
+              align-items: center;
+              gap: 4px;
+              max-width: 100%;
+              white-space: nowrap;
+              overflow: hidden;
+
+              span {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .badge-icon {
+                font-size: 14px;
+                width: 14px;
+                height: 14px;
+                flex-shrink: 0;
+              }
+
+              &.status-queued {
+                color: #ffb300;
+              }
+
+              &.status-preparing {
+                color: #38bdf8;
+              }
+
+              &.status-finalizing {
+                color: #a855f7;
+              }
+
+              &.status-completed {
+                color: #00e676;
+              }
+
+              &.status-failed {
+                color: #ff5252;
+                .error-msg {
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                }
+              }
+
+              &.status-cancelled {
+                color: #94a3b8;
+              }
+            }
+
+            .status-uploading {
+              display: flex;
+              align-items: center;
+              gap: 8px;
+
+              .progress-bar-track {
+                flex: 1;
+                height: 4px;
+                background: rgba(255, 255, 255, 0.1);
+                border-radius: 2px;
+                overflow: hidden;
+
+                .progress-bar-fill {
+                  height: 100%;
+                  background: #00e5ff;
+                  transition: width 0.2s ease-out;
+                }
+              }
+
+              .progress-pct-text {
+                font-weight: 600;
+                color: #00e5ff;
+                font-size: 11px;
+                min-width: 32px;
+                text-align: right;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    .panel-footer {
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.02);
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      justify-content: flex-end;
+
+      .retry-all-btn {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+        color: #ffffff;
+        border: none;
+        padding: 6px 12px;
+        border-radius: 8px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+        transition: all 0.2s ease;
+
+        &:hover {
+          background: linear-gradient(135deg, #f87171 0%, #ef4444 100%);
+          box-shadow: 0 6px 16px rgba(239, 68, 68, 0.45);
+        }
+
+        &:disabled {
+          background: rgba(255, 255, 255, 0.08);
+          color: rgba(255, 255, 255, 0.35);
+          box-shadow: none;
+          pointer-events: none;
+        }
+
+        mat-icon {
+          font-size: 16px;
+          width: 16px;
+          height: 16px;
+        }
+      }
+    }
+  }
+
+  /* BORDERLESS NON-BUTTON STATE INDICATORS */
+  .indicator-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 6px;
+    border: none;
+
+    .indicator-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &.indicator-success {
+      color: #00e676;
+      background: rgba(0, 230, 118, 0.12);
+    }
+
+    &.indicator-error {
+      color: #ff5252;
+      background: rgba(255, 82, 82, 0.12);
+    }
+
+    &.indicator-cancelled {
+      color: #94a3b8;
+      background: rgba(148, 163, 184, 0.12);
+    }
+  }
+
+  .icon-btn {
+    background: transparent;
+    border: none;
+    color: #94a3b8;
+    border-radius: 6px;
+    padding: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+
+    &:hover {
+      color: #f8fafc;
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &.close-btn {
+      &:disabled,
+      &.disabled {
+        opacity: 0.35;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.scss
@@ -34,11 +34,6 @@
     border-radius: 9999px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5), 0 0 1px rgba(255, 255, 255, 0.2);
 
-    &:hover {
-      background: rgba(28, 34, 46, 0.95);
-      border-color: rgba(255, 255, 255, 0.22);
-    }
-
     .pill-left {
       display: flex;
       align-items: center;

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.spec.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.spec.ts
@@ -15,9 +15,10 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {Router} from '@angular/router';
+import {NavigationEnd, Router} from '@angular/router';
 import {MatIconModule} from '@angular/material/icon';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {UploadProgressWidgetComponent} from './upload-progress-widget.component';
@@ -59,6 +60,7 @@ describe('UploadProgressWidgetComponent', () => {
         WorkspaceStateService,
         {provide: UserService, useValue: mockUserService},
       ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(UploadProgressWidgetComponent);
@@ -77,11 +79,13 @@ describe('UploadProgressWidgetComponent', () => {
 
   it('should detect login route correctly', () => {
     spyOnProperty(router, 'url', 'get').and.returnValue('/login');
+    (router.events as any).next(new NavigationEnd(1, '/login', '/login'));
     expect(component.isLoginRoute()).toBeTrue();
 
     (
       Object.getOwnPropertyDescriptor(router, 'url')?.get as jasmine.Spy
     ).and.returnValue('/gallery');
+    (router.events as any).next(new NavigationEnd(2, '/gallery', '/gallery'));
     expect(component.isLoginRoute()).toBeFalse();
   });
 
@@ -112,6 +116,7 @@ describe('UploadProgressWidgetComponent', () => {
     const itemInFlight: UploadItem = {
       id: 'item-1',
       filename: 'test.png',
+      originalFilename: 'test.png',
       size: 1024,
       mimeType: 'image/png',
       status: UploadStatus.UPLOADING,
@@ -132,6 +137,7 @@ describe('UploadProgressWidgetComponent', () => {
     const completedItem: UploadItem = {
       id: 'item-1',
       filename: 'done.png',
+      originalFilename: 'done.png',
       size: 1024,
       mimeType: 'image/png',
       status: UploadStatus.COMPLETED,
@@ -153,6 +159,7 @@ describe('UploadProgressWidgetComponent', () => {
     const failedItem: UploadItem = {
       id: 'item-fail',
       filename: 'error.png',
+      originalFilename: 'error.png',
       size: 1024,
       mimeType: 'image/png',
       status: UploadStatus.FAILED,
@@ -174,6 +181,7 @@ describe('UploadProgressWidgetComponent', () => {
       {
         id: 'f1',
         filename: 'f1.png',
+        originalFilename: 'f1.png',
         size: 100,
         mimeType: 'image/png',
         status: UploadStatus.FAILED,
@@ -182,6 +190,7 @@ describe('UploadProgressWidgetComponent', () => {
       {
         id: 'f2',
         filename: 'f2.png',
+        originalFilename: 'f2.png',
         size: 200,
         mimeType: 'image/png',
         status: UploadStatus.FAILED,
@@ -201,6 +210,7 @@ describe('UploadProgressWidgetComponent', () => {
       {
         id: '1',
         filename: 'file.png',
+        originalFilename: 'file.png',
         size: 100,
         mimeType: 'image/png',
         status: UploadStatus.COMPLETED,
@@ -236,6 +246,7 @@ describe('UploadProgressWidgetComponent', () => {
       {
         id: 'item-queued',
         filename: 'queued.png',
+        originalFilename: 'queued.png',
         size: 100,
         mimeType: 'image/png',
         status: UploadStatus.QUEUED,
@@ -244,6 +255,7 @@ describe('UploadProgressWidgetComponent', () => {
       {
         id: 'item-completed',
         filename: 'done.png',
+        originalFilename: 'done.png',
         size: 200,
         mimeType: 'image/png',
         status: UploadStatus.COMPLETED,
@@ -281,6 +293,7 @@ describe('UploadProgressWidgetComponent', () => {
       {
         id: 'item-cancelled',
         filename: 'cancelled.png',
+        originalFilename: 'cancelled.png',
         size: 300,
         mimeType: 'image/png',
         status: UploadStatus.CANCELLED,

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.spec.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Router} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {UploadProgressWidgetComponent} from './upload-progress-widget.component';
+import {
+  MediaUploadService,
+  UploadItem,
+  UploadStatus,
+} from '../../services/media-upload/media-upload.service';
+import {WorkspaceStateService} from '../../../services/workspace/workspace-state.service';
+import {UserService} from '../../services/user.service';
+
+describe('UploadProgressWidgetComponent', () => {
+  let component: UploadProgressWidgetComponent;
+  let fixture: ComponentFixture<UploadProgressWidgetComponent>;
+  let uploadService: MediaUploadService;
+  let workspaceService: WorkspaceStateService;
+  let router: Router;
+  let mockUserService: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    mockUserService = jasmine.createSpyObj('UserService', ['getUserDetails']);
+    mockUserService.getUserDetails.and.returnValue({
+      email: 'test@google.com',
+      name: 'Test User',
+      picture: '',
+      roles: [],
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MatIconModule,
+        MatProgressSpinnerModule,
+      ],
+      declarations: [UploadProgressWidgetComponent],
+      providers: [
+        MediaUploadService,
+        WorkspaceStateService,
+        {provide: UserService, useValue: mockUserService},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UploadProgressWidgetComponent);
+    component = fixture.componentInstance;
+    uploadService = TestBed.inject(MediaUploadService);
+    workspaceService = TestBed.inject(WorkspaceStateService);
+    router = TestBed.inject(Router);
+    workspaceService.setActiveWorkspaceId(123);
+    fixture.detectChanges();
+  });
+
+  it('should create component', () => {
+    expect(component).toBeTruthy();
+    expect(component.isExpanded()).toBeTrue();
+  });
+
+  it('should detect login route correctly', () => {
+    spyOnProperty(router, 'url', 'get').and.returnValue('/login');
+    expect(component.isLoginRoute()).toBeTrue();
+
+    (
+      Object.getOwnPropertyDescriptor(router, 'url')?.get as jasmine.Spy
+    ).and.returnValue('/gallery');
+    expect(component.isLoginRoute()).toBeFalse();
+  });
+
+  it('should toggle expanded and minimized states', () => {
+    expect(component.isExpanded()).toBeTrue();
+    component.toggleExpand();
+    expect(component.isExpanded()).toBeFalse();
+    component.toggleExpand();
+    expect(component.isExpanded()).toBeTrue();
+  });
+
+  it('should format file icons correctly based on mimeType', () => {
+    expect(component.getFileIcon('image/jpeg')).toBe('image');
+    expect(component.getFileIcon('video/mp4')).toBe('videocam');
+    expect(component.getFileIcon('audio/wav')).toBe('audiotrack');
+    expect(component.getFileIcon('application/pdf')).toBe('insert_drive_file');
+    expect(component.getFileIcon('')).toBe('insert_drive_file');
+  });
+
+  it('should format file sizes cleanly', () => {
+    expect(component.formatFileSize(0)).toBe('0 B');
+    expect(component.formatFileSize(512)).toBe('512 B');
+    expect(component.formatFileSize(1024 * 500)).toBe('500 KB');
+    expect(component.formatFileSize(1024 * 1024 * 14.2)).toBe('14.2 MB');
+  });
+
+  it('should disable close button when uploads are in progress', () => {
+    const itemInFlight: UploadItem = {
+      id: 'item-1',
+      filename: 'test.png',
+      size: 1024,
+      mimeType: 'image/png',
+      status: UploadStatus.UPLOADING,
+      progress: 40,
+    };
+
+    uploadService.uploadQueue.set([itemInFlight]);
+    fixture.detectChanges();
+
+    expect(uploadService.canClose()).toBeFalse();
+
+    component.onClose();
+    // Queue should remain intact because clearQueue is guarded by canClose
+    expect(uploadService.uploadQueue().length).toBe(1);
+  });
+
+  it('should enable close button and clear queue when transfers reach terminal state', () => {
+    const completedItem: UploadItem = {
+      id: 'item-1',
+      filename: 'done.png',
+      size: 1024,
+      mimeType: 'image/png',
+      status: UploadStatus.COMPLETED,
+      progress: 100,
+    };
+
+    uploadService.uploadQueue.set([completedItem]);
+    fixture.detectChanges();
+
+    expect(uploadService.canClose()).toBeTrue();
+
+    component.onClose();
+    expect(uploadService.uploadQueue().length).toBe(0);
+  });
+
+  it('should invoke retryUpload when item retry action is triggered', () => {
+    spyOn(uploadService, 'retryUpload');
+
+    const failedItem: UploadItem = {
+      id: 'item-fail',
+      filename: 'error.png',
+      size: 1024,
+      mimeType: 'image/png',
+      status: UploadStatus.FAILED,
+      progress: 0,
+      errorMessage: 'Network timeout',
+    };
+
+    uploadService.uploadQueue.set([failedItem]);
+    fixture.detectChanges();
+
+    component.onRetryItem('item-fail');
+    expect(uploadService.retryUpload).toHaveBeenCalledWith(123, 'item-fail');
+  });
+
+  it('should invoke retryAllFailed when retry all button is clicked', () => {
+    spyOn(uploadService, 'retryAllFailed');
+
+    const failedItems: UploadItem[] = [
+      {
+        id: 'f1',
+        filename: 'f1.png',
+        size: 100,
+        mimeType: 'image/png',
+        status: UploadStatus.FAILED,
+        progress: 0,
+      },
+      {
+        id: 'f2',
+        filename: 'f2.png',
+        size: 200,
+        mimeType: 'image/png',
+        status: UploadStatus.FAILED,
+        progress: 0,
+      },
+    ];
+
+    uploadService.uploadQueue.set(failedItems);
+    fixture.detectChanges();
+
+    component.onRetryAll();
+    expect(uploadService.retryAllFailed).toHaveBeenCalledWith(123);
+  });
+
+  it('should render shared header template in expanded and minimized states', () => {
+    uploadService.uploadQueue.set([
+      {
+        id: '1',
+        filename: 'file.png',
+        size: 100,
+        mimeType: 'image/png',
+        status: UploadStatus.COMPLETED,
+        progress: 100,
+      },
+    ]);
+    fixture.detectChanges();
+
+    // Expanded mode
+    expect(component.isExpanded()).toBeTrue();
+    const expandedHeader = fixture.nativeElement.querySelector('.panel-header');
+    expect(expandedHeader).toBeTruthy();
+    expect(expandedHeader.querySelector('.pill-title')?.textContent).toContain(
+      'Uploads:',
+    );
+
+    // Minimized mode
+    component.toggleExpand();
+    fixture.detectChanges();
+    expect(component.isExpanded()).toBeFalse();
+    const minimizedPill =
+      fixture.nativeElement.querySelector('.minimized-pill');
+    expect(minimizedPill).toBeTruthy();
+    expect(minimizedPill.querySelector('.pill-title')?.textContent).toContain(
+      'Uploads:',
+    );
+  });
+
+  it('should render cancel button for uncompleted uploads and invoke cancelUpload on click', () => {
+    spyOn(uploadService, 'cancelUpload');
+
+    uploadService.uploadQueue.set([
+      {
+        id: 'item-queued',
+        filename: 'queued.png',
+        size: 100,
+        mimeType: 'image/png',
+        status: UploadStatus.QUEUED,
+        progress: 0,
+      },
+      {
+        id: 'item-completed',
+        filename: 'done.png',
+        size: 200,
+        mimeType: 'image/png',
+        status: UploadStatus.COMPLETED,
+        progress: 100,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const queuedRow = fixture.nativeElement.querySelector(
+      '#upload-item-item-queued',
+    );
+    const completedRow = fixture.nativeElement.querySelector(
+      '#upload-item-item-completed',
+    );
+
+    expect(queuedRow).toBeTruthy();
+    expect(completedRow).toBeTruthy();
+
+    const queuedCancelBtn = queuedRow.querySelector('#cancel-btn-item-queued');
+    const completedCancelBtn = completedRow.querySelector(
+      '#cancel-btn-item-completed',
+    );
+
+    expect(queuedCancelBtn).toBeTruthy();
+    expect(completedCancelBtn).toBeNull();
+
+    queuedCancelBtn.click();
+    fixture.detectChanges();
+
+    expect(uploadService.cancelUpload).toHaveBeenCalledWith('item-queued');
+  });
+
+  it('should display cancelled indicators in header when there are cancelled items', () => {
+    uploadService.uploadQueue.set([
+      {
+        id: 'item-cancelled',
+        filename: 'cancelled.png',
+        size: 300,
+        mimeType: 'image/png',
+        status: UploadStatus.CANCELLED,
+        progress: 0,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const cancelledIndicator = fixture.nativeElement.querySelector(
+      '.indicator-cancelled',
+    );
+    expect(cancelledIndicator).toBeTruthy();
+    expect(cancelledIndicator.textContent).toContain('1');
+  });
+});

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
@@ -30,15 +30,16 @@ import {WorkspaceStateService} from '../../../services/workspace/workspace-state
 export class UploadProgressWidgetComponent {
   readonly isExpanded = signal<boolean>(true);
   readonly UploadStatus = UploadStatus;
+  readonly isLoginRoute = signal<boolean>(false);
 
   constructor(
     public uploadService: MediaUploadService,
     private workspaceStateService: WorkspaceStateService,
     private router: Router,
-  ) {}
-
-  isLoginRoute(): boolean {
-    return this.router.url.startsWith('/login');
+  ) {
+    this.router.events.subscribe(() =>
+      this.isLoginRoute.set(this.router.url.startsWith('/login')),
+    );
   }
 
   toggleExpand(): void {

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
@@ -21,6 +21,7 @@ import {
   UploadStatus,
 } from '../../services/media-upload/media-upload.service';
 import {WorkspaceStateService} from '../../../services/workspace/workspace-state.service';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-upload-progress-widget',
@@ -37,9 +38,11 @@ export class UploadProgressWidgetComponent {
     private workspaceStateService: WorkspaceStateService,
     private router: Router,
   ) {
-    this.router.events.subscribe(() =>
-      this.isLoginRoute.set(this.router.url.startsWith('/login')),
-    );
+    this.router.events
+      .pipe(takeUntilDestroyed())
+      .subscribe(() =>
+        this.isLoginRoute.set(this.router.url.startsWith('/login')),
+      );
   }
 
   toggleExpand(): void {

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
@@ -15,13 +15,14 @@
  */
 
 import {Component, signal} from '@angular/core';
-import {Router} from '@angular/router';
+import {NavigationEnd, Router} from '@angular/router';
 import {
   MediaUploadService,
   UploadStatus,
 } from '../../services/media-upload/media-upload.service';
 import {WorkspaceStateService} from '../../../services/workspace/workspace-state.service';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {filter} from 'rxjs';
 
 @Component({
   selector: 'app-upload-progress-widget',
@@ -39,7 +40,12 @@ export class UploadProgressWidgetComponent {
     private router: Router,
   ) {
     this.router.events
-      .pipe(takeUntilDestroyed())
+      .pipe(
+        filter(
+          (event): event is NavigationEnd => event instanceof NavigationEnd,
+        ),
+        takeUntilDestroyed(),
+      )
       .subscribe(() =>
         this.isLoginRoute.set(this.router.url.startsWith('/login')),
       );

--- a/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
+++ b/frontend/src/app/common/components/upload-progress-widget/upload-progress-widget.component.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, signal} from '@angular/core';
+import {Router} from '@angular/router';
+import {
+  MediaUploadService,
+  UploadStatus,
+} from '../../services/media-upload/media-upload.service';
+import {WorkspaceStateService} from '../../../services/workspace/workspace-state.service';
+
+@Component({
+  selector: 'app-upload-progress-widget',
+  templateUrl: './upload-progress-widget.component.html',
+  styleUrls: ['./upload-progress-widget.component.scss'],
+})
+export class UploadProgressWidgetComponent {
+  readonly isExpanded = signal<boolean>(true);
+  readonly UploadStatus = UploadStatus;
+
+  constructor(
+    public uploadService: MediaUploadService,
+    private workspaceStateService: WorkspaceStateService,
+    private router: Router,
+  ) {}
+
+  isLoginRoute(): boolean {
+    return this.router.url.startsWith('/login');
+  }
+
+  toggleExpand(): void {
+    this.isExpanded.update(val => !val);
+  }
+
+  onClose(): void {
+    if (this.uploadService.canClose()) {
+      this.uploadService.clearQueue();
+    }
+  }
+
+  onCancelItem(itemId: string): void {
+    this.uploadService.cancelUpload(itemId);
+  }
+
+  onRetryItem(itemId: string): void {
+    const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+    if (workspaceId !== null) {
+      this.uploadService.retryUpload(workspaceId, itemId);
+    }
+  }
+
+  onRetryAll(): void {
+    const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+    if (workspaceId !== null) {
+      this.uploadService.retryAllFailed(workspaceId);
+    }
+  }
+
+  getFileIcon(mimeType: string): string {
+    if (!mimeType) return 'insert_drive_file';
+    if (mimeType.startsWith('image/')) return 'image';
+    if (mimeType.startsWith('video/')) return 'videocam';
+    if (mimeType.startsWith('audio/')) return 'audiotrack';
+    return 'insert_drive_file';
+  }
+
+  formatFileSize(bytes: number): string {
+    if (!bytes || bytes <= 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+  }
+}

--- a/frontend/src/app/common/services/google-drive/google-drive.service.spec.ts
+++ b/frontend/src/app/common/services/google-drive/google-drive.service.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {GoogleDriveService, DriveFileMetadata} from './google-drive.service';
+import {environment} from '../../../../environments/environment';
+
+describe('GoogleDriveService', () => {
+  let service: GoogleDriveService;
+  let httpMock: HttpTestingController;
+  let snackBar: MatSnackBar;
+  let mockPickerDocs: any[];
+  let mockPickerAction: string;
+
+  beforeEach(() => {
+    environment.GOOGLE_CLIENT_ID = 'test-client-id';
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        MatSnackBarModule,
+        NoopAnimationsModule,
+      ],
+      providers: [GoogleDriveService],
+    });
+    service = TestBed.inject(GoogleDriveService);
+    httpMock = TestBed.inject(HttpTestingController);
+    snackBar = TestBed.inject(MatSnackBar);
+
+    mockPickerDocs = [];
+    mockPickerAction = 'picked';
+
+    // Set up default window.gapi and window.google mocks
+    (window as any).gapi = {
+      load: (api: string, config: any) => config.callback(),
+      picker: {
+        ViewId: {
+          DOCS_IMAGES: 'DOCS_IMAGES',
+          DOCS_VIDEOS: 'DOCS_VIDEOS',
+          DOCS: 'DOCS',
+        },
+        Feature: {MULTISELECT_ENABLED: 'MULTISELECT_ENABLED'},
+        Response: {ACTION: 'action', DOCUMENTS: 'docs'},
+        Action: {PICKED: 'picked', CANCEL: 'cancel'},
+        Document: {
+          ID: 'id',
+          NAME: 'name',
+          MIME_TYPE: 'mimeType',
+          SIZE_BYTES: 'sizeBytes',
+        },
+        View: class {
+          setMimeTypes() {}
+          setLabel() {}
+        },
+        PickerBuilder: class {
+          addView() {
+            return this;
+          }
+          setOAuthToken() {
+            return this;
+          }
+          enableFeature() {
+            return this;
+          }
+          setCallback(cb: any) {
+            this.cb = cb;
+            return this;
+          }
+          setDeveloperKey() {
+            return this;
+          }
+          setAppId() {
+            return this;
+          }
+          build() {
+            return {
+              setVisible: () => {
+                this.cb({
+                  action: mockPickerAction,
+                  docs: mockPickerDocs,
+                });
+              },
+              dispose: jasmine.createSpy('dispose'),
+            };
+          }
+          private cb: any;
+        },
+      },
+    };
+
+    (window as any).google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: (config: any) => ({
+            requestAccessToken: () => {
+              config.callback({access_token: 'test-token'});
+            },
+          }),
+        },
+      },
+      picker: (window as any).gapi.picker,
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    delete (window as any).gapi;
+    delete (window as any).google;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should handle missing gapi error when opening picker', fakeAsync(() => {
+    delete (window as any).gapi;
+    spyOn(snackBar, 'open');
+    let result: File[] | undefined;
+
+    service.openPicker().subscribe(files => {
+      result = files;
+    });
+    tick(100);
+
+    expect(result).toEqual([]);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Failed to open Google Drive Picker or download files.',
+      'Close',
+      {duration: 4000, panelClass: ['google-drive-snackbar']},
+    );
+  }));
+
+  it('should successfully launch picker and download selected files', fakeAsync(() => {
+    const mockAccessToken = 'test-token';
+    const mockDoc: DriveFileMetadata = {
+      id: 'file-123',
+      name: 'test-image.png',
+      mimeType: 'image/png',
+      sizeBytes: 1024,
+    };
+    mockPickerDocs = [
+      {
+        id: mockDoc.id,
+        name: mockDoc.name,
+        mimeType: mockDoc.mimeType,
+        sizeBytes: mockDoc.sizeBytes,
+      },
+    ];
+
+    let result: File[] | undefined;
+    service.openPicker().subscribe(files => {
+      result = files;
+    });
+    tick(100);
+
+    const req = httpMock.expectOne(
+      `https://www.googleapis.com/drive/v3/files/${mockDoc.id}?alt=media`,
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${mockAccessToken}`,
+    );
+    req.flush(new Blob(['test content'], {type: 'image/png'}));
+    tick(100);
+
+    expect(result?.length).toBe(1);
+    expect(result?.[0].name).toBe(mockDoc.name);
+    expect(result?.[0].type).toBe(mockDoc.mimeType);
+  }));
+
+  it('should display snackbar when downloading large files', fakeAsync(() => {
+    const mockDoc: DriveFileMetadata = {
+      id: 'large-file-123',
+      name: 'large-video.mp4',
+      mimeType: 'video/mp4',
+      sizeBytes: 300 * 1024 * 1024, // 300MB
+    };
+    mockPickerDocs = [
+      {
+        id: mockDoc.id,
+        name: mockDoc.name,
+        mimeType: mockDoc.mimeType,
+        sizeBytes: mockDoc.sizeBytes,
+      },
+    ];
+
+    spyOn(snackBar, 'open');
+
+    service.openPicker().subscribe();
+    tick(100);
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      `Downloading ${mockDoc.name} from Google Drive...`,
+      undefined,
+      {duration: 60000, panelClass: ['google-drive-snackbar']},
+    );
+
+    const req = httpMock.expectOne(
+      `https://www.googleapis.com/drive/v3/files/${mockDoc.id}?alt=media`,
+    );
+    req.flush(new Blob(['video content'], {type: 'video/mp4'}));
+    tick(100);
+  }));
+
+  it('should handle user cancellation in picker dialog', fakeAsync(() => {
+    mockPickerAction = 'cancel';
+
+    let result: File[] | undefined;
+    service.openPicker().subscribe(files => {
+      result = files;
+    });
+    tick(100);
+
+    expect(result).toEqual([]);
+  }));
+
+  it('should handle file download failure', fakeAsync(() => {
+    spyOn(snackBar, 'open');
+    const mockDoc: DriveFileMetadata = {
+      id: 'fail-file-123',
+      name: 'fail-image.png',
+      mimeType: 'image/png',
+    };
+    mockPickerDocs = [
+      {
+        id: mockDoc.id,
+        name: mockDoc.name,
+        mimeType: mockDoc.mimeType,
+      },
+    ];
+
+    let result: File[] | undefined;
+    service.openPicker().subscribe(files => {
+      result = files;
+    });
+    tick(100);
+
+    const req = httpMock.expectOne(
+      `https://www.googleapis.com/drive/v3/files/${mockDoc.id}?alt=media`,
+    );
+    req.flush(new Blob(['Error']), {status: 500, statusText: 'Server Error'});
+    tick(100);
+
+    expect(result).toEqual([]);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Failed to download fail-image.png',
+      'Close',
+      {
+        duration: 3000,
+        panelClass: ['google-drive-snackbar'],
+      },
+    );
+  }));
+
+  it('should handle missing google.accounts.oauth2 library error', fakeAsync(() => {
+    spyOn(snackBar, 'open');
+    (window as any).google = {};
+
+    let result: File[] | undefined;
+    service.openPicker().subscribe(files => {
+      result = files;
+    });
+    tick(100);
+
+    expect(result).toEqual([]);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Failed to open Google Drive Picker or download files.',
+      'Close',
+      {duration: 4000, panelClass: ['google-drive-snackbar']},
+    );
+  }));
+
+  it('should clean up stale picker DOM elements on open', fakeAsync(() => {
+    const staleElem = document.createElement('div');
+    staleElem.className = 'picker-dialog-bg';
+    document.body.appendChild(staleElem);
+
+    expect(document.querySelector('.picker-dialog-bg')).toBeTruthy();
+
+    service.openPicker().subscribe();
+    tick(100);
+
+    expect(document.querySelector('.picker-dialog-bg')).toBeNull();
+  }));
+});

--- a/frontend/src/app/common/services/google-drive/google-drive.service.ts
+++ b/frontend/src/app/common/services/google-drive/google-drive.service.ts
@@ -84,6 +84,9 @@ export class GoogleDriveService {
   }
 
   private requestAccessToken(): Promise<string> {
+    if (this.cachedAccessToken) {
+      return Promise.resolve(this.cachedAccessToken);
+    }
     return new Promise<string>((resolve, reject) => {
       if (typeof google === 'undefined' || !google.accounts?.oauth2) {
         reject(new Error('Google Identity Services (GIS) library not loaded.'));
@@ -244,6 +247,9 @@ export class GoogleDriveService {
         map(blob => new File([blob], doc.name, {type: doc.mimeType})),
         catchError(err => {
           console.error(`Failed to download file ${doc.name} from Drive:`, err);
+          if (err.status === 401) {
+            this.cachedAccessToken = null;
+          }
           this.openSnackBar(`Failed to download ${doc.name}`, 'Close', 3000);
           return of(null);
         }),

--- a/frontend/src/app/common/services/google-drive/google-drive.service.ts
+++ b/frontend/src/app/common/services/google-drive/google-drive.service.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {Injectable, inject} from '@angular/core';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {Observable, from, forkJoin, of} from 'rxjs';
+import {catchError, finalize, map, switchMap} from 'rxjs/operators';
+import {environment} from '../../../../environments/environment';
+
+declare const google: any;
+declare const gapi: any;
+
+export interface DriveFileMetadata {
+  id: string;
+  name: string;
+  mimeType: string;
+  sizeBytes?: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GoogleDriveService {
+  private http = inject(HttpClient);
+  private snackBar = inject(MatSnackBar);
+  private cachedAccessToken: string | null = null;
+  private isPickerApiLoaded = false;
+
+  /**
+   * Opens the Google Drive Picker dialog and returns an Observable of downloaded File objects.
+   */
+  openPicker(): Observable<File[]> {
+    return from(this.ensurePickerApiLoaded()).pipe(
+      switchMap(() => this.requestAccessToken()),
+      switchMap(token => this.showPickerDialog(token)),
+      switchMap(docs => {
+        if (!docs || docs.length === 0) {
+          return of([]);
+        }
+        return this.downloadFiles(docs);
+      }),
+      catchError(error => {
+        console.error('Error in Google Drive Picker workflow:', error);
+        this.openSnackBar(
+          'Failed to open Google Drive Picker or download files.',
+          'Close',
+          4000,
+        );
+        return of([]);
+      }),
+    );
+  }
+
+  private async ensurePickerApiLoaded(): Promise<void> {
+    if (this.isPickerApiLoaded && typeof gapi !== 'undefined' && gapi.picker) {
+      return;
+    }
+    if (typeof gapi === 'undefined') {
+      throw new Error('Google API client library (gapi) is not loaded.');
+    }
+    return new Promise<void>((resolve, reject) => {
+      gapi.load('picker', {
+        callback: () => {
+          this.isPickerApiLoaded = true;
+          resolve();
+        },
+        onerror: () => reject(new Error('Failed to load Google Picker API.')),
+      });
+    });
+  }
+
+  private requestAccessToken(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      if (typeof google === 'undefined' || !google.accounts?.oauth2) {
+        reject(new Error('Google Identity Services (GIS) library not loaded.'));
+        return;
+      }
+
+      const client_id = environment.GOOGLE_CLIENT_ID;
+      if (!client_id) {
+        reject(new Error('GOOGLE_CLIENT_ID is not configured in environment.'));
+        return;
+      }
+
+      const tokenClient = google.accounts.oauth2.initTokenClient({
+        client_id,
+        scope: 'https://www.googleapis.com/auth/drive.readonly',
+        callback: (response: any) => {
+          if (response.error) {
+            reject(response);
+            return;
+          }
+          this.cachedAccessToken = response.access_token;
+          resolve(response.access_token);
+        },
+      });
+
+      // Use silent prompt if we already have a cached token, otherwise prompt user
+      tokenClient.requestAccessToken({prompt: ''});
+    });
+  }
+
+  private showPickerDialog(accessToken: string): Promise<DriveFileMetadata[]> {
+    return new Promise<DriveFileMetadata[]>((resolve, reject) => {
+      try {
+        this.cleanupPickerElements(null);
+
+        const recentView = new google.picker.View(
+          google.picker.ViewId.RECENTLY_PICKED,
+        );
+        const imageView = new google.picker.View(
+          google.picker.ViewId.DOCS_IMAGES,
+        );
+        const videoView = new google.picker.View(
+          google.picker.ViewId.DOCS_VIDEOS,
+        );
+        const audioView = new google.picker.View(google.picker.ViewId.DOCS);
+        audioView.setLabel('Audio Files');
+        audioView.setMimeTypes(
+          'audio/wav,audio/mpeg,audio/mp3,audio/ogg,audio/webm',
+        );
+        const allFilesView = new google.picker.View(google.picker.ViewId.DOCS);
+        allFilesView.setLabel('All Files');
+
+        let picker: any = null;
+
+        const builder = new google.picker.PickerBuilder()
+          .addView(recentView)
+          .addView(imageView)
+          .addView(videoView)
+          .addView(audioView)
+          .addView(allFilesView)
+          .setOAuthToken(accessToken)
+          .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
+          .setCallback((data: any) => {
+            let metadataList: DriveFileMetadata[] = [];
+            const action = data[google.picker.Response.ACTION];
+            if (action === google.picker.Action.PICKED) {
+              const docs = data[google.picker.Response.DOCUMENTS] || [];
+              metadataList = docs.map((doc: any) => ({
+                id: doc[google.picker.Document.ID],
+                name: doc[google.picker.Document.NAME],
+                mimeType: doc[google.picker.Document.MIME_TYPE],
+                sizeBytes: doc[google.picker.Document.SIZE_BYTES]
+                  ? Number(doc[google.picker.Document.SIZE_BYTES])
+                  : undefined,
+              }));
+            }
+            if (
+              [
+                google.picker.Action.PICKED,
+                google.picker.Action.CANCEL,
+              ].includes(action)
+            ) {
+              this.cleanupPickerElements(picker);
+              resolve(metadataList);
+            }
+          });
+
+        if ((environment as any).PICKER_API_KEY) {
+          builder.setDeveloperKey((environment as any).PICKER_API_KEY);
+        }
+
+        const appId = environment.GOOGLE_CLIENT_ID?.split('-')[0];
+        if (appId) {
+          builder.setAppId(appId);
+        }
+
+        picker = builder.build();
+        picker.setVisible(true);
+
+        setTimeout(() => {
+          window.scrollTo({top: 0, behavior: 'instant'});
+          const bgElements = document.querySelectorAll(
+            '.picker-dialog-bg, .picker-modal-dialog-bg',
+          );
+          bgElements.forEach(bg => {
+            bg.addEventListener(
+              'click',
+              () => {
+                this.cleanupPickerElements(picker);
+                resolve([]);
+              },
+              {once: true},
+            );
+          });
+        }, 100);
+      } catch (error) {
+        this.cleanupPickerElements(null);
+        reject(error);
+      }
+    });
+  }
+
+  private cleanupPickerElements(picker: any | null): void {
+    if (picker) {
+      try {
+        picker.setVisible(false);
+        if (typeof picker.dispose === 'function') {
+          picker.dispose();
+        }
+      } catch {
+        // Ignore errors during picker cleanup
+      }
+    }
+    const elements = document.querySelectorAll(
+      '.picker-dialog, .picker-dialog-bg, .picker-modal-dialog, .picker-modal-dialog-bg',
+    );
+    elements.forEach(el => el.remove());
+  }
+
+  private downloadFiles(docs: DriveFileMetadata[]): Observable<File[]> {
+    if (!this.cachedAccessToken) {
+      return of([]);
+    }
+
+    const message =
+      docs.length === 1
+        ? `Downloading ${docs[0].name} from Google Drive...`
+        : `Downloading ${docs.length} files from Google Drive...`;
+    const snackBarRef = this.openSnackBar(message, undefined, 60000);
+
+    const downloadObservables = docs.map(doc => {
+      const headers = new HttpHeaders({
+        Authorization: `Bearer ${this.cachedAccessToken}`,
+      });
+
+      const url = `https://www.googleapis.com/drive/v3/files/${doc.id}?alt=media`;
+      return this.http.get(url, {headers, responseType: 'blob'}).pipe(
+        map(blob => new File([blob], doc.name, {type: doc.mimeType})),
+        catchError(err => {
+          console.error(`Failed to download file ${doc.name} from Drive:`, err);
+          this.openSnackBar(`Failed to download ${doc.name}`, 'Close', 3000);
+          return of(null);
+        }),
+      );
+    });
+
+    return forkJoin(downloadObservables).pipe(
+      map(files => files.filter((f): f is File => f !== null)),
+      finalize(() => snackBarRef.dismiss()),
+    );
+  }
+
+  private openSnackBar(message: string, action?: string, duration = 4000) {
+    return this.snackBar.open(message, action, {
+      duration,
+      panelClass: ['google-drive-snackbar'],
+    });
+  }
+}

--- a/frontend/src/app/common/services/media-upload/media-upload.constants.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.constants.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ALLOWED_MIME_TYPES: readonly string[] = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'image/avif',
+  'video/mp4',
+  'audio/wav',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/ogg',
+  'audio/webm',
+];
+
+export const ACCEPTED_MEDIA_UPLOAD_FORMATS =
+  ALLOWED_MIME_TYPES.join(',') + ',.heic,.heif,.avif';

--- a/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
@@ -110,10 +110,17 @@ describe('MediaUploadService', () => {
     const mp4File = createDummyFile('test.mp4', 'video/mp4');
     const wavFile = createDummyFile('test.wav', 'audio/wav');
     const pdfFile = createDummyFile('test.pdf', 'application/pdf');
+    const octetPngFile = createDummyFile(
+      'test.png',
+      'application/octet-stream',
+    );
+    const emptyTypeMp4 = createDummyFile('test.mp4', '');
 
     expect(service.isAllowedFileType(pngFile)).toBeTrue();
     expect(service.isAllowedFileType(mp4File)).toBeTrue();
     expect(service.isAllowedFileType(wavFile)).toBeTrue();
+    expect(service.isAllowedFileType(octetPngFile)).toBeTrue();
+    expect(service.isAllowedFileType(emptyTypeMp4)).toBeTrue();
     expect(service.isAllowedFileType(pdfFile)).toBeFalse();
   });
 
@@ -126,6 +133,23 @@ describe('MediaUploadService', () => {
     expect(service.uploadQueue()[0].errorMessage).toContain(
       'Unsupported format',
     );
+  });
+
+  it('should deduce mimeType from extension when file.type is empty or application/octet-stream', () => {
+    const unknownTypeFile = createDummyFile('sample.mp4', '');
+    const octetStreamFile = createDummyFile(
+      'track.mp3',
+      'application/octet-stream',
+    );
+
+    service.uploadFiles(mockWorkspaceId, [unknownTypeFile, octetStreamFile]);
+
+    const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+    expect(reqs.length).toBe(2);
+
+    const items = service.uploadQueue();
+    expect(items[0].mimeType).toBe('video/mp4');
+    expect(items[1].mimeType).toBe('audio/mpeg');
   });
 
   describe('Concurrency & Queue Throttling (Max 5 Concurrent Uploads)', () => {
@@ -572,7 +596,7 @@ describe('MediaUploadService', () => {
       const failedItem = freshService.uploadQueue().find(i => i.id === '2');
       expect(failedItem?.status).toBe(UploadStatus.FAILED);
       expect(failedItem?.errorMessage).toBe(
-        'Upload interrupted by page reload.',
+        'File binary payload missing from memory. Please re-upload from your device.',
       );
     });
 

--- a/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
@@ -21,8 +21,9 @@ import {
 import {TestBed} from '@angular/core/testing';
 import {HttpEventType, HttpResponse} from '@angular/common/http';
 import {Event, NavigationEnd, Router} from '@angular/router';
-import {Subject} from 'rxjs';
+import {of, Subject} from 'rxjs';
 import {environment} from '../../../../environments/environment';
+import {SourceAssetService} from '../source-asset.service';
 import {
   MediaUploadService,
   UploadItem,
@@ -37,6 +38,7 @@ describe('MediaUploadService', () => {
   let service: MediaUploadService;
   let httpMock: HttpTestingController;
   let mockUserService: jasmine.SpyObj<UserService>;
+  let mockSourceAssetService: jasmine.SpyObj<SourceAssetService>;
   let mockRouter: jasmine.SpyObj<Router>;
   let routerEventsSubject: Subject<Event>;
 
@@ -63,6 +65,10 @@ describe('MediaUploadService', () => {
       roles: [],
     });
 
+    mockSourceAssetService = jasmine.createSpyObj('SourceAssetService', [
+      'convertImageToPng',
+    ]);
+
     routerEventsSubject = new Subject<Event>();
     mockRouter = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
     (mockRouter as any).events = routerEventsSubject.asObservable();
@@ -72,6 +78,7 @@ describe('MediaUploadService', () => {
       providers: [
         MediaUploadService,
         {provide: UserService, useValue: mockUserService},
+        {provide: SourceAssetService, useValue: mockSourceAssetService},
         {provide: Router, useValue: mockRouter},
       ],
     });
@@ -525,6 +532,7 @@ describe('MediaUploadService', () => {
         {
           id: '1',
           filename: 'done.png',
+          originalFilename: 'done.png',
           size: 100,
           mimeType: 'image/png',
           status: UploadStatus.COMPLETED,
@@ -533,6 +541,7 @@ describe('MediaUploadService', () => {
         {
           id: '2',
           filename: 'interrupted.png',
+          originalFilename: 'interrupted.png',
           size: 200,
           mimeType: 'image/png',
           status: UploadStatus.UPLOADING,
@@ -552,6 +561,7 @@ describe('MediaUploadService', () => {
             TestBed.inject(MediaUploadService)['http'],
             TestBed.inject(UserService),
             TestBed.inject(Router),
+            TestBed.inject(SourceAssetService),
           ),
       );
 
@@ -658,8 +668,8 @@ describe('MediaUploadService', () => {
       // Let's verify statuses:
       const queue = service.uploadQueue();
       expect(queue[0].status).toBe(UploadStatus.COMPLETED);
-      expect(queue[1].status).toBe(UploadStatus.CANCELLED);
-      expect(queue[1].errorMessage).toBeUndefined();
+      expect(queue[1].status).toBe(UploadStatus.FAILED);
+      expect(queue[1].errorMessage).toBe('Some error');
       expect(queue[2].status).toBe(UploadStatus.CANCELLED);
       expect(queue[3].status).toBe(UploadStatus.CANCELLED);
       expect(queue[4].status).toBe(UploadStatus.CANCELLED);
@@ -677,7 +687,9 @@ describe('MediaUploadService', () => {
       const parsed: UploadItem[] = JSON.parse(stored!);
       expect(parsed.length).toBe(8);
       expect(parsed[0].status).toBe(UploadStatus.COMPLETED);
-      for (let i = 1; i <= 7; i++) {
+      expect(parsed[1].status).toBe(UploadStatus.FAILED);
+      expect(parsed[1].errorMessage).toBe('Some error');
+      for (let i = 2; i <= 7; i++) {
         expect(parsed[i].status).toBe(UploadStatus.CANCELLED);
         expect(parsed[i].errorMessage).toBeUndefined();
       }
@@ -712,6 +724,68 @@ describe('MediaUploadService', () => {
       const openReqs = httpMock.match(() => true);
       expect(openReqs.length).toBe(1);
       expect(openReqs[0].cancelled).toBeTrue();
+    });
+  });
+
+  describe('Pre-upload Format Conversion (AVIF, HEIC, HEIF)', () => {
+    it('should convert avif, heic, and heif files to png before requesting signed upload url', () => {
+      const fileHeic = createDummyFile('photo.heic', 'image/heic', 500);
+      const fakePngBlob = new Blob(['png-bytes'], {type: 'image/png'});
+      mockSourceAssetService.convertImageToPng.and.returnValue(of(fakePngBlob));
+
+      service.uploadFiles(mockWorkspaceId, [fileHeic]);
+
+      expect(mockSourceAssetService.convertImageToPng).toHaveBeenCalledWith(
+        fileHeic,
+      );
+      const req = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      expect(req.request.body.filename).toBe('photo.png');
+      expect(req.request.body.contentType).toBe('image/png');
+      expect(service.uploadQueue()[0].originalFilename).toBe('photo.heic');
+      expect(service.uploadQueue()[0].filename).toBe('photo.png');
+    });
+  });
+
+  describe('Session Storage Restoration on Auth Confirmation', () => {
+    it('should restore queue from sessionStorage on initialization', () => {
+      const mockItem: UploadItem = {
+        id: 'test-restore-id',
+        file: createDummyFile('test.png'),
+        filename: 'test.png',
+        originalFilename: 'test.png',
+        size: 1024,
+        mimeType: 'image/png',
+        status: UploadStatus.COMPLETED,
+        progress: 100,
+      };
+      sessionStorage.setItem(
+        MOCK_SESSION_STORAGE_UPLOAD_KEY,
+        JSON.stringify([mockItem]),
+      );
+
+      const newService = TestBed.runInInjectionContext(
+        () =>
+          new MediaUploadService(
+            TestBed.inject(HttpTestingController) as any,
+            mockUserService,
+            mockRouter,
+            mockSourceAssetService,
+          ),
+      );
+      // Trigger restoration check
+      expect(newService.uploadQueue().length).toBe(1);
+      expect(newService.uploadQueue()[0].id).toBe('test-restore-id');
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should remove beforeunload listener and clear active subscriptions when destroyed', () => {
+      spyOn(window, 'removeEventListener');
+      service.ngOnDestroy();
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        'beforeunload',
+        jasmine.any(Function),
+      );
     });
   });
 });

--- a/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.spec.ts
@@ -1,0 +1,717 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import {TestBed} from '@angular/core/testing';
+import {HttpEventType, HttpResponse} from '@angular/common/http';
+import {Event, NavigationEnd, Router} from '@angular/router';
+import {Subject} from 'rxjs';
+import {environment} from '../../../../environments/environment';
+import {
+  MediaUploadService,
+  UploadItem,
+  UploadStatus,
+} from './media-upload.service';
+import {UserService} from '../user.service';
+
+const MOCK_SESSION_STORAGE_UPLOAD_KEY =
+  'cs_media_uploads_active_job_test@google.com';
+
+describe('MediaUploadService', () => {
+  let service: MediaUploadService;
+  let httpMock: HttpTestingController;
+  let mockUserService: jasmine.SpyObj<UserService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let routerEventsSubject: Subject<Event>;
+
+  const mockWorkspaceId = 123;
+  const apiUrl = `${environment.backendURL}/source_assets`;
+
+  function createDummyFile(
+    name: string,
+    type = 'image/png',
+    size = 1024,
+  ): File {
+    const blob = new Blob(['a'.repeat(size)], {type});
+    return new File([blob], name, {type});
+  }
+
+  beforeEach(() => {
+    sessionStorage.removeItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+
+    mockUserService = jasmine.createSpyObj('UserService', ['getUserDetails']);
+    mockUserService.getUserDetails.and.returnValue({
+      email: 'test@google.com',
+      name: 'Test User',
+      picture: '',
+      roles: [],
+    });
+
+    routerEventsSubject = new Subject<Event>();
+    mockRouter = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
+    (mockRouter as any).events = routerEventsSubject.asObservable();
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        MediaUploadService,
+        {provide: UserService, useValue: mockUserService},
+        {provide: Router, useValue: mockRouter},
+      ],
+    });
+
+    service = TestBed.inject(MediaUploadService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sessionStorage.removeItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+  });
+
+  it('should be created with initial empty state', () => {
+    expect(service).toBeTruthy();
+    expect(service.uploadQueue()).toEqual([]);
+    expect(service.totalCount()).toBe(0);
+    expect(service.totalUploaded()).toBe(0);
+    expect(service.totalFailed()).toBe(0);
+    expect(service.inProgressCount()).toBe(0);
+    expect(service.queuedCount()).toBe(0);
+    expect(service.overallProgress()).toBe(0);
+    expect(service.canClose()).toBeTrue();
+    expect(service.hasActiveOrFinishedUploads()).toBeFalse();
+  });
+
+  it('should validate allowed file types correctly', () => {
+    const pngFile = createDummyFile('test.png', 'image/png');
+    const mp4File = createDummyFile('test.mp4', 'video/mp4');
+    const wavFile = createDummyFile('test.wav', 'audio/wav');
+    const pdfFile = createDummyFile('test.pdf', 'application/pdf');
+
+    expect(service.isAllowedFileType(pngFile)).toBeTrue();
+    expect(service.isAllowedFileType(mp4File)).toBeTrue();
+    expect(service.isAllowedFileType(wavFile)).toBeTrue();
+    expect(service.isAllowedFileType(pdfFile)).toBeFalse();
+  });
+
+  it('should mark unsupported file formats as FAILED immediately', () => {
+    const pdfFile = createDummyFile('invalid.pdf', 'application/pdf');
+    service.uploadFiles(mockWorkspaceId, [pdfFile]);
+
+    expect(service.totalCount()).toBe(1);
+    expect(service.totalFailed()).toBe(1);
+    expect(service.uploadQueue()[0].errorMessage).toContain(
+      'Unsupported format',
+    );
+  });
+
+  describe('Concurrency & Queue Throttling (Max 5 Concurrent Uploads)', () => {
+    it('should limit active simultaneous uploads to maximum 5 files', () => {
+      const files = Array.from({length: 8}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.totalCount()).toBe(8);
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(3);
+
+      // Verify 5 generate-upload-url requests are created
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(5);
+
+      reqs.forEach((req, idx) => {
+        expect(req.request.body).toEqual({
+          workspaceId: mockWorkspaceId,
+          filename: `file_${idx + 1}.png`,
+          contentType: 'image/png',
+          size: 1024,
+        });
+      });
+    });
+
+    it('should trigger the next queued file as active uploads complete', () => {
+      const files = Array.from({length: 6}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(1);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(5);
+
+      // Complete the first file's signed URL generation, GCS upload, and finalization
+      const firstReq = reqs[0];
+      firstReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-url-1',
+        gcsUri: 'gs://test-bucket/uploads/file_1.png',
+        fileUuid: 'uuid-1',
+      });
+
+      // GCS PUT request
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-url-1',
+      );
+      putReq.flush(null, {status: 200, statusText: 'OK'});
+
+      // Finalize request
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      expect(finalizeReq.request.body).toEqual({
+        workspaceId: mockWorkspaceId,
+        gcsUri: 'gs://test-bucket/uploads/file_1.png',
+        filename: 'file_1.png',
+        mimeType: 'image/png',
+        size: 1024,
+        assetType: 'generic_image',
+      });
+      finalizeReq.flush({id: 1, originalFilename: 'file_1.png'});
+
+      // Upon completion of file 1, file 6 should be picked up automatically
+      expect(service.totalUploaded()).toBe(1);
+      expect(service.queuedCount()).toBe(0);
+
+      const newReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      expect(newReq.request.body.filename).toBe('file_6.png');
+    });
+  });
+
+  describe('Full Upload Flow & Progress Calculation', () => {
+    it('should track upload progress and emit batch completion when done', done => {
+      let batchCompleted = false;
+      service.uploadBatchComplete$.subscribe(() => {
+        batchCompleted = true;
+      });
+
+      const file = createDummyFile('test-video.mp4', 'video/mp4', 2048);
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      // 1. Signed URL request
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-url-vid',
+        gcsUri: 'gs://test-bucket/uploads/test-video.mp4',
+        fileUuid: 'vid-uuid',
+      });
+
+      // 2. GCS PUT upload with progress
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-url-vid',
+      );
+
+      // Emit 50% upload progress event
+      putReq.event({
+        type: HttpEventType.UploadProgress,
+        loaded: 1024,
+        total: 2048,
+      });
+      expect(service.overallProgress()).toBe(50);
+
+      // Complete PUT response
+      putReq.event(new HttpResponse({status: 200}));
+
+      // 3. Finalize upload
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      expect(finalizeReq.request.body.assetType).toBe('generic_video');
+      finalizeReq.flush({id: 2, originalFilename: 'test-video.mp4'});
+
+      expect(service.totalUploaded()).toBe(1);
+      expect(service.overallProgress()).toBe(100);
+      expect(service.isBatchFinished()).toBeTrue();
+      expect(batchCompleted).toBeTrue();
+      done();
+    });
+  });
+
+  describe('Error Handling & Retries', () => {
+    it('should mark item as FAILED when generate signed URL errors', () => {
+      const file = createDummyFile('fail-url.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush(
+        {detail: 'File is too large'},
+        {status: 413, statusText: 'Payload Too Large'},
+      );
+
+      expect(service.totalFailed()).toBe(1);
+      const failedItem = service.uploadQueue()[0];
+      expect(failedItem.status).toBe(UploadStatus.FAILED);
+      expect(failedItem.errorMessage).toBe('File is too large');
+      expect(service.canClose()).toBeTrue();
+    });
+
+    it('should support retryUpload for failed items', () => {
+      const file = createDummyFile('retry.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush(
+        {detail: 'Network error'},
+        {status: 500, statusText: 'Error'},
+      );
+
+      expect(service.totalFailed()).toBe(1);
+      const itemId = service.uploadQueue()[0].id;
+
+      // Retry single failed upload
+      service.retryUpload(mockWorkspaceId, itemId);
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.GENERATING_URL);
+
+      const retryGenReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      retryGenReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-retry',
+        gcsUri: 'gs://test-bucket/retry.png',
+        fileUuid: 'retry-uuid',
+      });
+
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-retry',
+      );
+      putReq.flush(null, {status: 200, statusText: 'OK'});
+
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      finalizeReq.flush({id: 1});
+    });
+
+    it('should support retryAllFailed for multiple failed items', () => {
+      const files = [createDummyFile('f1.png'), createDummyFile('f2.png')];
+      service.uploadFiles(mockWorkspaceId, files);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      reqs.forEach(r =>
+        r.flush(
+          {detail: 'Backend failure'},
+          {status: 500, statusText: 'Error'},
+        ),
+      );
+
+      expect(service.totalFailed()).toBe(2);
+
+      service.retryAllFailed(mockWorkspaceId);
+
+      const retryReqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(retryReqs.length).toBe(2);
+      retryReqs.forEach(r =>
+        r.flush(
+          {detail: 'Backend failure'},
+          {status: 500, statusText: 'Error'},
+        ),
+      );
+    });
+
+    it('should not retryUpload if file has unsupported format', () => {
+      const invalidFile = createDummyFile('unsupported.pdf', 'application/pdf');
+      service.uploadFiles(mockWorkspaceId, [invalidFile]);
+
+      expect(service.totalFailed()).toBe(1);
+      const itemId = service.uploadQueue()[0].id;
+
+      service.retryUpload(mockWorkspaceId, itemId);
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.FAILED);
+      expect(service.uploadQueue()[0].errorMessage).toContain(
+        'Unsupported format',
+      );
+    });
+
+    it('should not retryAllFailed for items with unsupported format', () => {
+      const files = [
+        createDummyFile('valid.png'),
+        createDummyFile('unsupported.pdf', 'application/pdf'),
+      ];
+      service.uploadFiles(mockWorkspaceId, files);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush(
+        {detail: 'Network error'},
+        {status: 500, statusText: 'Error'},
+      );
+
+      expect(service.totalFailed()).toBe(2);
+
+      service.retryAllFailed(mockWorkspaceId);
+
+      // Only the valid.png should be retried (expecting one generate-upload-url request)
+      const retryReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      retryReq.flush({
+        uploadUrl: 'https://storage.googleapis.com/test-bucket/signed-retry',
+        gcsUri: 'gs://test-bucket/retry.png',
+        fileUuid: 'retry-uuid',
+      });
+
+      const putReq = httpMock.expectOne(
+        'https://storage.googleapis.com/test-bucket/signed-retry',
+      );
+      putReq.flush(null, {status: 200, statusText: 'OK'});
+
+      const finalizeReq = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      finalizeReq.flush({id: 1});
+
+      // The invalid file should remain FAILED
+      const invalidItem = service
+        .uploadQueue()
+        .find(i => i.filename === 'unsupported.pdf');
+      expect(invalidItem?.status).toBe(UploadStatus.FAILED);
+    });
+  });
+
+  describe('Individual Item Upload Cancellation', () => {
+    it('should cancel a queued file without triggering any request', () => {
+      const files = Array.from({length: 6}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(1);
+
+      const queuedItem = service
+        .uploadQueue()
+        .find(i => i.status === UploadStatus.QUEUED)!;
+      expect(queuedItem).toBeTruthy();
+
+      service.cancelUpload(queuedItem.id);
+
+      const updatedItem = service
+        .uploadQueue()
+        .find(i => i.id === queuedItem.id)!;
+      expect(updatedItem.status).toBe(UploadStatus.CANCELLED);
+      expect(service.queuedCount()).toBe(0);
+      expect(service.totalCancelled()).toBe(1);
+
+      // Clean up outstanding requests in the testing backend
+      httpMock
+        .match(() => true)
+        .forEach(req => req.error(new ProgressEvent('error')));
+    });
+
+    it('should cancel an active file, abort request, and trigger the next queued file', () => {
+      const files = Array.from({length: 6}, (_, i) =>
+        createDummyFile(`file_${i + 1}.png`),
+      );
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(1);
+
+      const activeItem = service
+        .uploadQueue()
+        .find(i => i.status === UploadStatus.GENERATING_URL)!;
+      expect(activeItem).toBeTruthy();
+
+      const reqsBefore = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqsBefore.length).toBe(5);
+
+      // Cancel the active item
+      service.cancelUpload(activeItem.id);
+
+      const updatedItem = service
+        .uploadQueue()
+        .find(i => i.id === activeItem.id)!;
+      expect(updatedItem.status).toBe(UploadStatus.CANCELLED);
+      expect(service.totalCancelled()).toBe(1);
+
+      // A slot should be released, so the 6th file (queued) should be triggered immediately
+      const newReqs = httpMock.match(
+        req =>
+          req.url === `${apiUrl}/generate-upload-url` &&
+          req.body?.filename === 'file_6.png',
+      );
+      expect(newReqs.length).toBe(1);
+      expect(newReqs[0].request.body.filename).toBe('file_6.png');
+
+      // Clean up outstanding requests in the testing backend
+      httpMock
+        .match(() => true)
+        .forEach(req => req.error(new ProgressEvent('error')));
+    });
+
+    it('should exclude cancelled and failed files from overall progress calculation', () => {
+      const files = [
+        createDummyFile('completed.png'),
+        createDummyFile('failed.png'),
+        createDummyFile('cancelled.png'),
+        createDummyFile('uploading.png'),
+      ];
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(4);
+
+      const items = service.uploadQueue();
+      const cancId = items[2].id;
+
+      // 1. Cancel file 3
+      service.cancelUpload(cancId);
+      expect(service.totalCancelled()).toBe(1);
+
+      // 2. Fail file 2
+      reqs[1].flush({detail: 'Failed'}, {status: 500, statusText: 'Error'});
+      expect(service.totalFailed()).toBe(1);
+
+      // 3. Complete file 1
+      reqs[0].flush({
+        uploadUrl: 'http://url1',
+        gcsUri: 'gs://uri1',
+      });
+      const put1 = httpMock.expectOne('http://url1');
+      put1.flush(null);
+      const fin1 = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      fin1.flush({id: 1});
+      expect(service.totalUploaded()).toBe(1);
+
+      // 4. Update file 4 progress to 50%
+      reqs[3].flush({
+        uploadUrl: 'http://url4',
+        gcsUri: 'gs://uri4',
+      });
+      const put4 = httpMock.expectOne('http://url4');
+      put4.event({
+        type: HttpEventType.UploadProgress,
+        loaded: 512,
+        total: 1024,
+      });
+
+      // Valid items: completed (100% progress) and uploading (50% progress)
+      // Overall progress: Math.round((100 + 50) / 2) = 75%
+      expect(service.overallProgress()).toBe(75);
+
+      // Clean up outstanding requests in the testing backend
+      httpMock
+        .match(() => true)
+        .forEach(req => req.error(new ProgressEvent('error')));
+    });
+  });
+
+  describe('SessionStorage Persistence & Reload Recovery', () => {
+    it('should sync queue state to sessionStorage without file binary blobs', () => {
+      const file = createDummyFile('sync.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const req = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      req.flush({detail: 'Pause'}, {status: 500, statusText: 'Error'});
+
+      const stored = sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+      expect(stored).toBeTruthy();
+
+      const parsed: UploadItem[] = JSON.parse(stored!);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].filename).toBe('sync.png');
+      expect(parsed[0].file).toBeUndefined();
+    });
+
+    it('should restore state on service instantiation and mark in-flight transfers as FAILED', () => {
+      const savedItems: UploadItem[] = [
+        {
+          id: '1',
+          filename: 'done.png',
+          size: 100,
+          mimeType: 'image/png',
+          status: UploadStatus.COMPLETED,
+          progress: 100,
+        },
+        {
+          id: '2',
+          filename: 'interrupted.png',
+          size: 200,
+          mimeType: 'image/png',
+          status: UploadStatus.UPLOADING,
+          progress: 45,
+        },
+      ];
+
+      sessionStorage.setItem(
+        MOCK_SESSION_STORAGE_UPLOAD_KEY,
+        JSON.stringify(savedItems),
+      );
+
+      // Re-instantiate service within injection context
+      const freshService = TestBed.runInInjectionContext(
+        () =>
+          new MediaUploadService(
+            TestBed.inject(MediaUploadService)['http'],
+            TestBed.inject(UserService),
+            TestBed.inject(Router),
+          ),
+      );
+
+      expect(freshService.totalCount()).toBe(2);
+      expect(freshService.totalUploaded()).toBe(1);
+      expect(freshService.totalFailed()).toBe(1);
+
+      const failedItem = freshService.uploadQueue().find(i => i.id === '2');
+      expect(failedItem?.status).toBe(UploadStatus.FAILED);
+      expect(failedItem?.errorMessage).toBe(
+        'Upload interrupted by page reload.',
+      );
+    });
+
+    it('should clear queue and remove sessionStorage key when clearQueue is invoked', () => {
+      const file = createDummyFile('clear.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      const genReq = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+      genReq.flush({detail: 'Error'}, {status: 400, statusText: 'Bad Request'});
+
+      expect(service.canClose()).toBeTrue();
+      service.clearQueue();
+
+      expect(service.uploadQueue()).toEqual([]);
+      expect(
+        sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY),
+      ).toBeNull();
+    });
+  });
+
+  describe('Route-based Cancellation on /login Navigation', () => {
+    it('should cancel all queued, in-flight, and failed uploads when navigating to /login', () => {
+      const files = [
+        createDummyFile('file0.png'), // Will complete
+        createDummyFile('file1.png'), // Will fail
+        createDummyFile('file2.png'), // Will remain in-flight (GENERATING_URL)
+        createDummyFile('file3.png'), // Will remain in-flight (UPLOADING)
+        createDummyFile('file4.png'), // Will remain in-flight (FINALIZING)
+        createDummyFile('file5.png'), // Will remain QUEUED
+        createDummyFile('file6.png'), // Will remain QUEUED
+        createDummyFile('file7.png'), // Will remain QUEUED
+      ];
+
+      service.uploadFiles(mockWorkspaceId, files);
+
+      expect(service.inProgressCount()).toBe(5);
+      expect(service.queuedCount()).toBe(3);
+
+      const reqs = httpMock.match(`${apiUrl}/generate-upload-url`);
+      expect(reqs.length).toBe(5);
+
+      // f0: COMPLETED
+      reqs[0].flush({
+        uploadUrl: 'http://url0',
+        gcsUri: 'gs://uri0',
+      });
+      const put0 = httpMock.expectOne('http://url0');
+      put0.flush(null);
+      const fin0 = httpMock.expectOne(`${apiUrl}/finalize-upload`);
+      fin0.flush({id: 0});
+
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.COMPLETED);
+
+      // Now f5 starts GENERATING_URL because a slot opened up.
+      const reqForF5 = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+
+      // f1: FAILED
+      reqs[1].flush({detail: 'Some error'}, {status: 500, statusText: 'Error'});
+      expect(service.uploadQueue()[1].status).toBe(UploadStatus.FAILED);
+      expect(service.uploadQueue()[1].errorMessage).toBe('Some error');
+
+      // Now f6 starts GENERATING_URL because another slot opened up.
+      const reqForF6 = httpMock.expectOne(`${apiUrl}/generate-upload-url`);
+
+      // Now we have:
+      // f0: COMPLETED
+      // f1: FAILED
+      // f2: GENERATING_URL (reqs[2] is pending)
+      // f3: UPLOADING (transition from reqs[3])
+      reqs[3].flush({
+        uploadUrl: 'http://url3',
+        gcsUri: 'gs://uri3',
+      });
+      expect(service.uploadQueue()[3].status).toBe(UploadStatus.UPLOADING);
+
+      // f4: FINALIZING (transition from reqs[4])
+      reqs[4].flush({
+        uploadUrl: 'http://url4',
+        gcsUri: 'gs://uri4',
+      });
+      const put4 = httpMock.expectOne('http://url4');
+      put4.flush(null);
+      expect(service.uploadQueue()[4].status).toBe(UploadStatus.FINALIZING);
+
+      // f5: GENERATING_URL (reqForF5 is pending)
+      // f6: GENERATING_URL (reqForF6 is pending)
+      // f7: QUEUED (no slots since active are f2, f3, f4, f5, f6 -> 5 items in progress)
+      expect(service.uploadQueue()[7].status).toBe(UploadStatus.QUEUED);
+
+      // Now we navigate to /login by emitting event on router
+      routerEventsSubject.next(new NavigationEnd(1, '/login', '/login'));
+
+      // Let's verify statuses:
+      const queue = service.uploadQueue();
+      expect(queue[0].status).toBe(UploadStatus.COMPLETED);
+      expect(queue[1].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[1].errorMessage).toBeUndefined();
+      expect(queue[2].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[3].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[4].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[5].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[6].status).toBe(UploadStatus.CANCELLED);
+      expect(queue[7].status).toBe(UploadStatus.CANCELLED);
+
+      expect(service.inProgressCount()).toBe(0);
+      expect(service.queuedCount()).toBe(0);
+      expect(service.isBatchFinished()).toBeTrue();
+
+      // Check sessionStorage sync
+      const stored = sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+      expect(stored).toBeTruthy();
+      const parsed: UploadItem[] = JSON.parse(stored!);
+      expect(parsed.length).toBe(8);
+      expect(parsed[0].status).toBe(UploadStatus.COMPLETED);
+      for (let i = 1; i <= 7; i++) {
+        expect(parsed[i].status).toBe(UploadStatus.CANCELLED);
+        expect(parsed[i].errorMessage).toBeUndefined();
+      }
+
+      // Verify that the explicitly matched/expected requests were also cancelled
+      expect(reqs[2].cancelled).toBeTrue();
+      expect(reqForF5.cancelled).toBeTrue();
+      expect(reqForF6.cancelled).toBeTrue();
+
+      // Pull all other open requests from the mock backend registry
+      const openReqs = httpMock.match(() => true);
+      expect(openReqs.length).toBe(2); // PUT http://url3 and POST finalize-upload
+      openReqs.forEach(req => {
+        expect(req.cancelled).toBeTrue();
+      });
+    });
+
+    it('should also trigger cancelAllForLogin if urlAfterRedirects starts with /login', () => {
+      const file = createDummyFile('file.png');
+      service.uploadFiles(mockWorkspaceId, [file]);
+
+      routerEventsSubject.next(
+        new NavigationEnd(1, '/some-other-url', '/login?returnUrl=/dashboard'),
+      );
+
+      expect(service.uploadQueue()[0].status).toBe(UploadStatus.CANCELLED);
+      const stored = sessionStorage.getItem(MOCK_SESSION_STORAGE_UPLOAD_KEY);
+      const parsed: UploadItem[] = JSON.parse(stored!);
+      expect(parsed[0].status).toBe(UploadStatus.CANCELLED);
+
+      // Pull all open requests (there should be 1: POST generate-upload-url)
+      const openReqs = httpMock.match(() => true);
+      expect(openReqs.length).toBe(1);
+      expect(openReqs[0].cancelled).toBeTrue();
+    });
+  });
+});

--- a/frontend/src/app/common/services/media-upload/media-upload.service.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.ts
@@ -1,0 +1,681 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HttpClient,
+  HttpEvent,
+  HttpEventType,
+  HttpHeaders,
+} from '@angular/common/http';
+import {computed, effect, Injectable, signal} from '@angular/core';
+import {NavigationEnd, Router} from '@angular/router';
+import {Subject, Subscription} from 'rxjs';
+import {filter} from 'rxjs/operators';
+import {environment} from '../../../../environments/environment';
+import {UserService} from '../user.service';
+
+export enum UploadStatus {
+  QUEUED = 'QUEUED',
+  GENERATING_URL = 'GENERATING_URL',
+  UPLOADING = 'UPLOADING',
+  FINALIZING = 'FINALIZING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+}
+
+export interface UploadItem {
+  id: string;
+  file?: File;
+  filename: string;
+  size: number;
+  mimeType: string;
+  status: UploadStatus;
+  progress: number;
+  errorMessage?: string;
+  gcsUri?: string;
+  uploadUrl?: string;
+}
+
+export interface GenerateUploadUrlResponse {
+  uploadUrl: string;
+  gcsUri: string;
+  fileUuid: string;
+}
+
+export const SESSION_STORAGE_UPLOAD_KEY = 'cs_media_uploads_active_job';
+export const MAX_CONCURRENT_UPLOADS = 5;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MediaUploadService {
+  private readonly apiUrl = `${environment.backendURL}/source_assets`;
+
+  /**
+   * Primary Signal holding the active upload queue.
+   */
+  readonly uploadQueue = signal<UploadItem[]>([]);
+
+  /**
+   * Total count of successfully completed uploads in current queue.
+   */
+  readonly totalUploaded = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.COMPLETED)
+        .length,
+  );
+
+  /**
+   * Total count of failed uploads in current queue.
+   */
+  readonly totalFailed = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.FAILED)
+        .length,
+  );
+
+  /**
+   * Total count of cancelled uploads in current queue.
+   */
+  readonly totalCancelled = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.CANCELLED)
+        .length,
+  );
+
+  /**
+   * Total count of active uploads currently in progress.
+   */
+  readonly inProgressCount = computed(
+    () =>
+      this.uploadQueue().filter(item =>
+        [
+          UploadStatus.GENERATING_URL,
+          UploadStatus.UPLOADING,
+          UploadStatus.FINALIZING,
+        ].includes(item.status),
+      ).length,
+  );
+
+  /**
+   * Total count of items waiting in queue.
+   */
+  readonly queuedCount = computed(
+    () =>
+      this.uploadQueue().filter(item => item.status === UploadStatus.QUEUED)
+        .length,
+  );
+
+  /**
+   * Total number of items in the upload queue.
+   */
+  readonly totalCount = computed(() => this.uploadQueue().length);
+
+  /**
+   * Overall percentage completed across all non-failed and non-cancelled items in queue (0 - 100).
+   */
+  readonly overallProgress = computed(() => {
+    const queue = this.uploadQueue();
+    const validItems = queue.filter(
+      item =>
+        item.status !== UploadStatus.FAILED &&
+        item.status !== UploadStatus.CANCELLED,
+    );
+    if (validItems.length === 0) return 0;
+    const totalProgress = validItems.reduce(
+      (sum, item) => sum + (item.progress || 0),
+      0,
+    );
+    return Math.round(totalProgress / validItems.length);
+  });
+
+  /**
+   * Indicates whether the close button can be activated (no active transfers in flight).
+   */
+  readonly canClose = computed(() => this.inProgressCount() === 0);
+
+  /**
+   * Indicates whether the widget should be visible (queue has items).
+   */
+  readonly hasActiveOrFinishedUploads = computed(
+    () => this.uploadQueue().length > 0,
+  );
+
+  /**
+   * Indicates if all items in batch have reached terminal state (COMPLETED or FAILED).
+   */
+  readonly isBatchFinished = computed(() => {
+    const queue = this.uploadQueue();
+    return (
+      queue.length > 0 &&
+      this.inProgressCount() === 0 &&
+      this.queuedCount() === 0
+    );
+  });
+
+  /**
+   * Subject emitted when an entire upload batch finishes processing.
+   */
+  readonly uploadBatchComplete$ = new Subject<void>();
+  private lastUploadCompleteNotified = signal<number>(0);
+
+  private activeSubscriptions = new Map<string, Subscription>();
+  private activeWorkspaceId?: number;
+  private isBatchRunning = false;
+  private beforeUnloadHandler = (event: BeforeUnloadEvent): string => {
+    event.preventDefault();
+    event.returnValue = '';
+    return '';
+  };
+
+  constructor(
+    private http: HttpClient,
+    private userService: UserService,
+    private router: Router,
+  ) {
+    this.restoreQueueFromSessionStorage();
+
+    // Listen to router events to cancel uploads when navigating to /login
+    this.router.events
+      .pipe(
+        filter(
+          (event): event is NavigationEnd => event instanceof NavigationEnd,
+        ),
+      )
+      .subscribe(event => {
+        if (
+          event.urlAfterRedirects.startsWith('/login') ||
+          event.url.startsWith('/login')
+        ) {
+          this.cancelAllForLogin();
+        }
+      });
+
+    // Effect to attach/detach window beforeunload listener when transfers are active
+    effect(() => {
+      const inProgress = this.inProgressCount();
+      if (inProgress > 0) {
+        window.addEventListener('beforeunload', this.beforeUnloadHandler);
+      } else {
+        window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      }
+    });
+  }
+
+  private getSessionStorageKey(): string {
+    return `cs_media_uploads_active_job_${this.userService.getUserDetails()?.email || 'default'}`;
+  }
+
+  readonly ALLOWED_MIME_TYPES = [
+    'image/png',
+    'video/mp4',
+    'audio/wav',
+    'audio/mpeg',
+    'audio/mp3',
+    'audio/ogg',
+    'audio/webm',
+  ];
+
+  isAllowedFileType(file: File): boolean {
+    if (this.ALLOWED_MIME_TYPES.includes(file.type)) return true;
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    if (ext === 'png' && (file.type === 'image/png' || !file.type)) return true;
+    if (ext === 'mp4' && (file.type === 'video/mp4' || !file.type)) return true;
+    if (['wav', 'mp3', 'ogg', 'webm', 'mpeg'].includes(ext || '')) return true;
+    return false;
+  }
+
+  allowedFileTypeMessage(file: File): string | null {
+    return this.isAllowedFileType(file)
+      ? null
+      : 'Unsupported format. Allowed: PNG, MP4, Audio (WAV, MP3, OGG, WEBM)';
+  }
+
+  /**
+   * Initiates multi-file upload for selected files.
+   */
+  uploadFiles(workspaceId: number, files: File[]): void {
+    if (!files || files.length === 0) return;
+    this.activeWorkspaceId = workspaceId;
+
+    const newItems: UploadItem[] = files.map(file => {
+      const errorMessage = this.allowedFileTypeMessage(file);
+      return {
+        id: this.generateUniqueId(),
+        file,
+        filename: file.name,
+        size: file.size,
+        mimeType: file.type || 'application/octet-stream',
+        status: !errorMessage ? UploadStatus.QUEUED : UploadStatus.FAILED,
+        progress: 0,
+        errorMessage: errorMessage || undefined,
+      };
+    });
+
+    this.isBatchRunning = true;
+    this.uploadQueue.update(current => [...current, ...newItems]);
+    this.syncSessionStorage();
+    this.processQueue(workspaceId);
+  }
+
+  /**
+   * Cancels an upload for a specific file ID.
+   * If in QUEUED state, marks status as CANCELLED without starting HTTP request.
+   * If in active state (GENERATING_URL, UPLOADING, FINALIZING), aborts the active HTTP request,
+   * marks status as CANCELLED, releases concurrency pool slot, and triggers next queued file.
+   */
+  cancelUpload(fileId: string): void {
+    const item = this.uploadQueue().find(i => i.id === fileId);
+    if (!item) return;
+
+    const sub = this.activeSubscriptions.get(fileId);
+    if (sub) {
+      sub.unsubscribe();
+      this.activeSubscriptions.delete(fileId);
+    }
+
+    const isUncompleted = [
+      UploadStatus.QUEUED,
+      UploadStatus.GENERATING_URL,
+      UploadStatus.UPLOADING,
+      UploadStatus.FINALIZING,
+      UploadStatus.FAILED,
+    ].includes(item.status);
+
+    if (isUncompleted) {
+      this.updateItem(fileId, {
+        status: UploadStatus.CANCELLED,
+        errorMessage: undefined,
+      });
+
+      if (this.activeWorkspaceId !== undefined) {
+        this.processQueue(this.activeWorkspaceId);
+      }
+      this.checkBatchCompletion();
+    }
+  }
+
+  private cancelAllForLogin(): void {
+    this.activeSubscriptions.forEach(sub => sub.unsubscribe());
+    this.activeSubscriptions.clear();
+
+    this.uploadQueue.update(current =>
+      current.map(item =>
+        [
+          UploadStatus.QUEUED,
+          UploadStatus.GENERATING_URL,
+          UploadStatus.UPLOADING,
+          UploadStatus.FINALIZING,
+          UploadStatus.FAILED,
+        ].includes(item.status)
+          ? {...item, status: UploadStatus.CANCELLED, errorMessage: undefined}
+          : item,
+      ),
+    );
+
+    this.syncSessionStorage();
+    this.checkBatchCompletion();
+  }
+
+  /**
+   * Retries uploading a specific failed or cancelled item.
+   */
+  retryUpload(workspaceId: number, itemId: string): void {
+    const item = this.uploadQueue().find(i => i.id === itemId);
+    if (
+      !item ||
+      (item.status !== UploadStatus.FAILED &&
+        item.status !== UploadStatus.CANCELLED)
+    ) {
+      return;
+    }
+    this.activeWorkspaceId = workspaceId;
+
+    const errorMessage = item.file
+      ? this.allowedFileTypeMessage(item.file)
+      : null;
+    const allowed = !errorMessage;
+
+    this.updateItem(itemId, {
+      status: allowed ? UploadStatus.QUEUED : UploadStatus.FAILED,
+      progress: 0,
+      errorMessage: errorMessage || undefined,
+    });
+
+    if (allowed) {
+      this.isBatchRunning = true;
+      this.processQueue(workspaceId);
+    }
+  }
+
+  /**
+   * Retries all failed uploads in the queue.
+   */
+  retryAllFailed(workspaceId: number): void {
+    const queue = this.uploadQueue();
+    const failedItems = queue.filter(i => i.status === UploadStatus.FAILED);
+    if (failedItems.length === 0) return;
+    this.activeWorkspaceId = workspaceId;
+
+    this.uploadQueue.update(current =>
+      current.map(item => {
+        if (item.status === UploadStatus.FAILED) {
+          const errorMessage = item.file
+            ? this.allowedFileTypeMessage(item.file)
+            : null;
+          const allowed = !errorMessage;
+          return {
+            ...item,
+            status: allowed ? UploadStatus.QUEUED : UploadStatus.FAILED,
+            progress: 0,
+            errorMessage: errorMessage || undefined,
+          };
+        }
+        return item;
+      }),
+    );
+
+    this.isBatchRunning = true;
+    this.syncSessionStorage();
+    this.processQueue(workspaceId);
+  }
+
+  /**
+   * Clears queue from memory and removes sessionStorage state.
+   */
+  clearQueue(): void {
+    if (!this.canClose()) return;
+    this.activeSubscriptions.forEach(sub => sub.unsubscribe());
+    this.activeSubscriptions.clear();
+    this.uploadQueue.set([]);
+    this.lastUploadCompleteNotified.set(0);
+    this.isBatchRunning = false;
+    try {
+      sessionStorage.removeItem(this.getSessionStorageKey());
+    } catch (e) {
+      console.error('Failed to clear sessionStorage upload key:', e);
+    }
+  }
+
+  /**
+   * Processes the upload queue maintaining max 5 concurrent uploads.
+   */
+  processQueue(workspaceId: number): void {
+    this.activeWorkspaceId = workspaceId;
+    const queue = this.uploadQueue();
+    const inProgress = this.inProgressCount();
+    const availableSlots = MAX_CONCURRENT_UPLOADS - inProgress;
+
+    if (availableSlots <= 0) return;
+
+    const queuedItems = queue.filter(
+      item => item.status === UploadStatus.QUEUED,
+    );
+    const itemsToStart = queuedItems.slice(0, availableSlots);
+
+    for (const item of itemsToStart) {
+      this.executeUpload(workspaceId, item);
+    }
+
+    this.checkBatchCompletion();
+  }
+
+  private executeUpload(workspaceId: number, item: UploadItem): void {
+    this.updateItem(item.id, {
+      status: UploadStatus.GENERATING_URL,
+      progress: 0,
+    });
+
+    const generatePayload = {
+      workspaceId,
+      filename: item.filename,
+      contentType: item.mimeType,
+      size: item.size,
+    };
+
+    const sub = this.http
+      .post<GenerateUploadUrlResponse>(
+        `${this.apiUrl}/generate-upload-url`,
+        generatePayload,
+      )
+      .subscribe({
+        next: res => {
+          this.activeSubscriptions.delete(item.id);
+          this.updateItem(item.id, {
+            status: UploadStatus.UPLOADING,
+            gcsUri: res.gcsUri,
+            uploadUrl: res.uploadUrl,
+          });
+          this.performGcsPut(workspaceId, item.id, res.uploadUrl, item);
+        },
+        error: err => {
+          this.activeSubscriptions.delete(item.id);
+          this.handleUploadError(
+            workspaceId,
+            item.id,
+            err.error?.detail ||
+              err.message ||
+              'Failed to generate signed upload URL',
+          );
+        },
+      });
+
+    this.activeSubscriptions.set(item.id, sub);
+  }
+
+  private performGcsPut(
+    workspaceId: number,
+    itemId: string,
+    uploadUrl: string,
+    item: UploadItem,
+  ): void {
+    if (!item.file) {
+      this.handleUploadError(
+        workspaceId,
+        itemId,
+        'File binary payload missing from memory.',
+      );
+      return;
+    }
+
+    const headers = new HttpHeaders({'Content-Type': item.mimeType});
+
+    const sub = this.http
+      .put(uploadUrl, item.file, {
+        headers,
+        reportProgress: true,
+        observe: 'events',
+      })
+      .subscribe({
+        next: (event: HttpEvent<unknown>) => {
+          if (event.type === HttpEventType.UploadProgress) {
+            const progress = event.total
+              ? Math.round((100 * event.loaded) / event.total)
+              : Math.min(99, Math.round((100 * event.loaded) / item.size));
+            this.updateItem(itemId, {progress});
+          } else if (event.type === HttpEventType.Response) {
+            this.activeSubscriptions.delete(itemId);
+            this.updateItem(itemId, {
+              status: UploadStatus.FINALIZING,
+              progress: 100,
+            });
+            this.finalizeUpload(workspaceId, itemId);
+          }
+        },
+        error: err => {
+          this.activeSubscriptions.delete(itemId);
+          this.handleUploadError(
+            workspaceId,
+            itemId,
+            err.error?.detail || err.message || 'Direct GCS upload failed.',
+          );
+        },
+      });
+
+    this.activeSubscriptions.set(itemId, sub);
+  }
+
+  private finalizeUpload(workspaceId: number, itemId: string): void {
+    const item = this.uploadQueue().find(i => i.id === itemId);
+    if (!item || !item.gcsUri) {
+      this.handleUploadError(
+        workspaceId,
+        itemId,
+        'Missing GCS URI for upload finalization.',
+      );
+      return;
+    }
+
+    const finalizePayload = {
+      workspaceId,
+      gcsUri: item.gcsUri,
+      filename: item.filename,
+      mimeType: item.mimeType,
+      size: item.size,
+      assetType: this.determineAssetType(item.mimeType),
+    };
+
+    const sub = this.http
+      .post(`${this.apiUrl}/finalize-upload`, finalizePayload)
+      .subscribe({
+        next: () => {
+          this.activeSubscriptions.delete(itemId);
+          this.updateItem(itemId, {
+            status: UploadStatus.COMPLETED,
+            progress: 100,
+          });
+          this.processQueue(workspaceId);
+        },
+        error: err => {
+          this.activeSubscriptions.delete(itemId);
+          this.handleUploadError(
+            workspaceId,
+            itemId,
+            err.error?.detail ||
+              err.message ||
+              'Failed to finalize asset upload.',
+          );
+        },
+      });
+
+    this.activeSubscriptions.set(itemId, sub);
+  }
+
+  private handleUploadError(
+    workspaceId: number,
+    itemId: string,
+    errorMessage: string,
+  ): void {
+    this.updateItem(itemId, {
+      status: UploadStatus.FAILED,
+      errorMessage,
+    });
+    this.processQueue(workspaceId);
+  }
+
+  private updateItem(id: string, changes: Partial<UploadItem>): void {
+    this.uploadQueue.update(queue =>
+      queue.map(item => (item.id === id ? {...item, ...changes} : item)),
+    );
+    this.syncSessionStorage();
+  }
+
+  private checkBatchCompletion(): void {
+    if (this.isBatchRunning && this.isBatchFinished()) {
+      this.isBatchRunning = false;
+      const currentUploaded = this.totalUploaded();
+      if (this.lastUploadCompleteNotified() !== currentUploaded) {
+        this.lastUploadCompleteNotified.set(currentUploaded);
+        this.uploadBatchComplete$.next();
+      }
+    }
+  }
+
+  private syncSessionStorage(): void {
+    try {
+      const queueToStore = this.uploadQueue().map(item => ({
+        id: item.id,
+        filename: item.filename,
+        size: item.size,
+        mimeType: item.mimeType,
+        status: item.status,
+        progress: item.progress,
+        errorMessage: item.errorMessage,
+        gcsUri: item.gcsUri,
+        uploadUrl: item.uploadUrl,
+      }));
+      sessionStorage.setItem(
+        this.getSessionStorageKey(),
+        JSON.stringify(queueToStore),
+      );
+    } catch (e) {
+      console.error('Failed to sync upload queue to sessionStorage:', e);
+    }
+  }
+
+  private restoreQueueFromSessionStorage(): void {
+    try {
+      const stored = sessionStorage.getItem(this.getSessionStorageKey());
+      if (!stored) return;
+
+      const items: UploadItem[] = JSON.parse(stored);
+      if (Array.isArray(items) && items.length > 0) {
+        const restored = items.map(item => {
+          // If transfer was interrupted mid-flight when page reloaded
+          if (
+            [
+              UploadStatus.GENERATING_URL,
+              UploadStatus.UPLOADING,
+              UploadStatus.FINALIZING,
+            ].includes(item.status)
+          ) {
+            return {
+              ...item,
+              status: UploadStatus.FAILED,
+              errorMessage: 'Upload interrupted by page reload.',
+            };
+          }
+          return item;
+        });
+        this.uploadQueue.set(restored);
+        this.lastUploadCompleteNotified.set(
+          restored.filter(item => item.status === UploadStatus.COMPLETED)
+            .length,
+        );
+      }
+    } catch (e) {
+      console.error('Failed to restore upload queue from sessionStorage:', e);
+    }
+  }
+
+  private determineAssetType(mimeType: string): string {
+    if (mimeType.startsWith('image/')) {
+      return 'generic_image';
+    }
+    if (mimeType.startsWith('video/')) {
+      return 'generic_video';
+    }
+    return 'generic_image';
+  }
+
+  private generateUniqueId(): string {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return `upload_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }
+}

--- a/frontend/src/app/common/services/media-upload/media-upload.service.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.ts
@@ -20,15 +20,26 @@ import {
   HttpEventType,
   HttpHeaders,
 } from '@angular/common/http';
-import {computed, effect, Injectable, signal} from '@angular/core';
+import {
+  computed,
+  effect,
+  inject,
+  Injectable,
+  OnDestroy,
+  signal,
+} from '@angular/core';
+import {Auth, user} from '@angular/fire/auth';
 import {NavigationEnd, Router} from '@angular/router';
 import {Subject, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {environment} from '../../../../environments/environment';
+import {SourceAssetService} from '../source-asset.service';
 import {UserService} from '../user.service';
+import {ALLOWED_MIME_TYPES} from './media-upload.constants';
 
 export enum UploadStatus {
   QUEUED = 'QUEUED',
+  PREPROCESSING_FILE = 'PREPROCESSING_FILE',
   GENERATING_URL = 'GENERATING_URL',
   UPLOADING = 'UPLOADING',
   FINALIZING = 'FINALIZING',
@@ -41,6 +52,7 @@ export interface UploadItem {
   id: string;
   file?: File;
   filename: string;
+  originalFilename: string;
   size: number;
   mimeType: string;
   status: UploadStatus;
@@ -62,7 +74,7 @@ export const MAX_CONCURRENT_UPLOADS = 5;
 @Injectable({
   providedIn: 'root',
 })
-export class MediaUploadService {
+export class MediaUploadService implements OnDestroy {
   private readonly apiUrl = `${environment.backendURL}/source_assets`;
 
   /**
@@ -104,6 +116,7 @@ export class MediaUploadService {
     () =>
       this.uploadQueue().filter(item =>
         [
+          UploadStatus.PREPROCESSING_FILE,
           UploadStatus.GENERATING_URL,
           UploadStatus.UPLOADING,
           UploadStatus.FINALIZING,
@@ -173,6 +186,7 @@ export class MediaUploadService {
   readonly uploadBatchComplete$ = new Subject<void>();
   private lastUploadCompleteNotified = signal<number>(0);
 
+  private readonly auth = inject(Auth, {optional: true});
   private activeSubscriptions = new Map<string, Subscription>();
   private activeWorkspaceId?: number;
   private isBatchRunning = false;
@@ -186,8 +200,17 @@ export class MediaUploadService {
     private http: HttpClient,
     private userService: UserService,
     private router: Router,
+    private sourceAssetService: SourceAssetService,
   ) {
-    this.restoreQueueFromSessionStorage();
+    if (this.auth) {
+      user(this.auth).subscribe(u => {
+        if (u) {
+          this.restoreQueueFromSessionStorage();
+        }
+      });
+    } else {
+      this.restoreQueueFromSessionStorage();
+    }
 
     // Listen to router events to cancel uploads when navigating to /login
     this.router.events
@@ -212,30 +235,46 @@ export class MediaUploadService {
         if (inProgress > 0) {
           window.addEventListener('beforeunload', this.beforeUnloadHandler);
         } else {
-          window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+          this.removeBeforeUnload();
         }
       }
     });
   }
 
-  private getSessionStorageKey(): string {
-    return `cs_media_uploads_active_job_${this.userService.getUserDetails()?.email || 'default'}`;
+  ngOnDestroy(): void {
+    this.activeSubscriptions.forEach(sub => sub.unsubscribe());
+    this.activeSubscriptions.clear();
+    this.removeBeforeUnload();
   }
 
-  readonly ALLOWED_MIME_TYPES = [
-    'image/png',
-    'video/mp4',
-    'audio/wav',
-    'audio/mpeg',
-    'audio/mp3',
-    'audio/ogg',
-    'audio/webm',
-  ];
+  private removeBeforeUnload(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+    }
+  }
+
+  private getSessionStorageKey(): string {
+    const email =
+      this.auth?.currentUser?.email ||
+      this.userService.getUserDetails()?.email ||
+      'default';
+    return `cs_media_uploads_active_job_${email}`;
+  }
+
+  readonly ALLOWED_MIME_TYPES = ALLOWED_MIME_TYPES;
 
   isAllowedFileType(file: File): boolean {
     if (this.ALLOWED_MIME_TYPES.includes(file.type)) return true;
     const ext = file.name.split('.').pop()?.toLowerCase();
     if (ext === 'png' && (file.type === 'image/png' || !file.type)) return true;
+    if (
+      ['jpg', 'jpeg'].includes(ext || '') &&
+      (file.type === 'image/jpeg' || file.type === 'image/jpg' || !file.type)
+    )
+      return true;
+    if (ext === 'webp' && (file.type === 'image/webp' || !file.type))
+      return true;
+    if (['heic', 'heif', 'avif'].includes(ext || '')) return true;
     if (ext === 'mp4' && (file.type === 'video/mp4' || !file.type)) return true;
     if (['wav', 'mp3', 'ogg', 'webm', 'mpeg'].includes(ext || '')) return true;
     return false;
@@ -244,7 +283,7 @@ export class MediaUploadService {
   allowedFileTypeMessage(file: File): string | null {
     return this.isAllowedFileType(file)
       ? null
-      : 'Unsupported format. Allowed: PNG, MP4, Audio (WAV, MP3, OGG, WEBM)';
+      : 'Unsupported format. Allowed: Images (PNG, JPG, WEBP, HEIC, HEIF, AVIF), MP4, Audio (WAV, MP3, OGG, WEBM)';
   }
 
   /**
@@ -260,6 +299,7 @@ export class MediaUploadService {
         id: this.generateUniqueId(),
         file,
         filename: file.name,
+        originalFilename: file.name,
         size: file.size,
         mimeType: file.type || 'application/octet-stream',
         status: !errorMessage ? UploadStatus.QUEUED : UploadStatus.FAILED,
@@ -292,6 +332,7 @@ export class MediaUploadService {
 
     const isUncompleted = [
       UploadStatus.QUEUED,
+      UploadStatus.PREPROCESSING_FILE,
       UploadStatus.GENERATING_URL,
       UploadStatus.UPLOADING,
       UploadStatus.FINALIZING,
@@ -319,10 +360,10 @@ export class MediaUploadService {
       current.map(item =>
         [
           UploadStatus.QUEUED,
+          UploadStatus.PREPROCESSING_FILE,
           UploadStatus.GENERATING_URL,
           UploadStatus.UPLOADING,
           UploadStatus.FINALIZING,
-          UploadStatus.FAILED,
         ].includes(item.status)
           ? {...item, status: UploadStatus.CANCELLED, errorMessage: undefined}
           : item,
@@ -436,12 +477,79 @@ export class MediaUploadService {
     this.checkBatchCompletion();
   }
 
+  private requiresPngConversion(item: UploadItem): boolean {
+    const ext = item.filename.split('.').pop()?.toLowerCase() || '';
+    if (['heic', 'heif', 'avif'].includes(ext)) return true;
+    if (['image/heic', 'image/heif', 'image/avif'].includes(item.mimeType))
+      return true;
+    return false;
+  }
+
   private executeUpload(workspaceId: number, item: UploadItem): void {
     this.updateItem(item.id, {
       status: UploadStatus.GENERATING_URL,
       progress: 0,
     });
 
+    if (this.requiresPngConversion(item)) {
+      this.updateItem(item.id, {
+        status: UploadStatus.PREPROCESSING_FILE,
+        progress: 0,
+      });
+      if (!item.file) {
+        this.handleUploadError(
+          workspaceId,
+          item.id,
+          'File payload missing for conversion.',
+        );
+        return;
+      }
+      const sub = this.sourceAssetService
+        .convertImageToPng(item.file)
+        .subscribe({
+          next: (pngBlob: Blob) => {
+            this.activeSubscriptions.delete(item.id);
+            const baseName =
+              item.filename.substring(0, item.filename.lastIndexOf('.')) ||
+              item.filename;
+            const newFilename = `${baseName}.png`;
+            const convertedFile = new File([pngBlob], newFilename, {
+              type: 'image/png',
+            });
+            const itemUpdatedProps = {
+              file: convertedFile,
+              filename: newFilename,
+              size: convertedFile.size,
+              mimeType: 'image/png',
+            };
+            const updatedItem: UploadItem = {...item, ...itemUpdatedProps};
+            this.updateItem(item.id, itemUpdatedProps);
+            this.proceedWithSignedUrlGeneration(workspaceId, updatedItem);
+          },
+          error: err => {
+            this.activeSubscriptions.delete(item.id);
+            this.handleUploadError(
+              workspaceId,
+              item.id,
+              err.error?.detail ||
+                err.message ||
+                'Failed to convert image to PNG',
+            );
+          },
+        });
+      if (!sub.closed) {
+        this.activeSubscriptions.set(item.id, sub);
+      }
+      return;
+    }
+
+    this.proceedWithSignedUrlGeneration(workspaceId, item);
+  }
+
+  private proceedWithSignedUrlGeneration(
+    workspaceId: number,
+    item: UploadItem,
+  ): void {
     const generatePayload = {
       workspaceId,
       filename: item.filename,
@@ -530,7 +638,9 @@ export class MediaUploadService {
         },
       });
 
-    this.activeSubscriptions.set(itemId, sub);
+    if (!sub.closed) {
+      this.activeSubscriptions.set(itemId, sub);
+    }
   }
 
   private finalizeUpload(workspaceId: number, itemId: string): void {
@@ -576,7 +686,9 @@ export class MediaUploadService {
         },
       });
 
-    this.activeSubscriptions.set(itemId, sub);
+    if (!sub.closed) {
+      this.activeSubscriptions.set(itemId, sub);
+    }
   }
 
   private handleUploadError(
@@ -614,6 +726,7 @@ export class MediaUploadService {
       const queueToStore = this.uploadQueue().map(item => ({
         id: item.id,
         filename: item.filename,
+        originalFilename: item.originalFilename,
         size: item.size,
         mimeType: item.mimeType,
         status: item.status,
@@ -642,6 +755,8 @@ export class MediaUploadService {
           // If transfer was interrupted mid-flight when page reloaded
           if (
             [
+              UploadStatus.QUEUED,
+              UploadStatus.PREPROCESSING_FILE,
               UploadStatus.GENERATING_URL,
               UploadStatus.UPLOADING,
               UploadStatus.FINALIZING,

--- a/frontend/src/app/common/services/media-upload/media-upload.service.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.ts
@@ -747,7 +747,11 @@ export class MediaUploadService implements OnDestroy {
   private restoreQueueFromSessionStorage(): void {
     try {
       const stored = sessionStorage.getItem(this.getSessionStorageKey());
-      if (!stored) return;
+      if (!stored) {
+        this.uploadQueue.set([]);
+        this.lastUploadCompleteNotified.set(0);
+        return;
+      }
 
       const items: UploadItem[] = JSON.parse(stored);
       if (Array.isArray(items) && items.length > 0) {

--- a/frontend/src/app/common/services/media-upload/media-upload.service.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.ts
@@ -264,26 +264,37 @@ export class MediaUploadService implements OnDestroy {
   readonly ALLOWED_MIME_TYPES = ALLOWED_MIME_TYPES;
 
   isAllowedFileType(file: File): boolean {
-    if (this.ALLOWED_MIME_TYPES.includes(file.type)) return true;
-    const ext = file.name.split('.').pop()?.toLowerCase();
-    if (ext === 'png' && (file.type === 'image/png' || !file.type)) return true;
-    if (
-      ['jpg', 'jpeg'].includes(ext || '') &&
-      (file.type === 'image/jpeg' || file.type === 'image/jpg' || !file.type)
-    )
-      return true;
-    if (ext === 'webp' && (file.type === 'image/webp' || !file.type))
-      return true;
-    if (['heic', 'heif', 'avif'].includes(ext || '')) return true;
-    if (ext === 'mp4' && (file.type === 'video/mp4' || !file.type)) return true;
-    if (['wav', 'mp3', 'ogg', 'webm', 'mpeg'].includes(ext || '')) return true;
-    return false;
+    const deducedType = this.getFileType(file);
+    return this.ALLOWED_MIME_TYPES.includes(deducedType);
   }
 
   allowedFileTypeMessage(file: File): string | null {
     return this.isAllowedFileType(file)
       ? null
       : 'Unsupported format. Allowed: Images (PNG, JPG, WEBP, HEIC, HEIF, AVIF), MP4, Audio (WAV, MP3, OGG, WEBM)';
+  }
+
+  private getFileType(file: File): string {
+    let deducedMime = file.type;
+    if (!deducedMime || deducedMime === 'application/octet-stream') {
+      const ext = file.name.split('.').pop()?.toLowerCase();
+      const extMap: Record<string, string> = {
+        png: 'image/png',
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        webp: 'image/webp',
+        heic: 'image/heic',
+        heif: 'image/heif',
+        avif: 'image/avif',
+        mp4: 'video/mp4',
+        wav: 'audio/wav',
+        mp3: 'audio/mpeg',
+        ogg: 'audio/ogg',
+        webm: 'audio/webm',
+      };
+      deducedMime = extMap[ext || ''] || 'application/octet-stream';
+    }
+    return deducedMime;
   }
 
   /**
@@ -301,7 +312,7 @@ export class MediaUploadService implements OnDestroy {
         filename: file.name,
         originalFilename: file.name,
         size: file.size,
-        mimeType: file.type || 'application/octet-stream',
+        mimeType: this.getFileType(file),
         status: !errorMessage ? UploadStatus.QUEUED : UploadStatus.FAILED,
         progress: 0,
         errorMessage: errorMessage || undefined,
@@ -448,7 +459,9 @@ export class MediaUploadService implements OnDestroy {
     this.lastUploadCompleteNotified.set(0);
     this.isBatchRunning = false;
     try {
-      sessionStorage.removeItem(this.getSessionStorageKey());
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.removeItem(this.getSessionStorageKey());
+      }
     } catch (e) {
       console.error('Failed to clear sessionStorage upload key:', e);
     }
@@ -723,6 +736,7 @@ export class MediaUploadService implements OnDestroy {
 
   private syncSessionStorage(): void {
     try {
+      if (typeof sessionStorage === 'undefined') return;
       const queueToStore = this.uploadQueue().map(item => ({
         id: item.id,
         filename: item.filename,
@@ -746,6 +760,11 @@ export class MediaUploadService implements OnDestroy {
 
   private restoreQueueFromSessionStorage(): void {
     try {
+      if (typeof sessionStorage === 'undefined') {
+        this.uploadQueue.set([]);
+        this.lastUploadCompleteNotified.set(0);
+        return;
+      }
       const stored = sessionStorage.getItem(this.getSessionStorageKey());
       if (!stored) {
         this.uploadQueue.set([]);
@@ -769,7 +788,9 @@ export class MediaUploadService implements OnDestroy {
             return {
               ...item,
               status: UploadStatus.FAILED,
-              errorMessage: 'Upload interrupted by page reload.',
+              errorMessage: item.file
+                ? 'Upload interrupted by page reload.'
+                : 'File binary payload missing from memory. Please re-upload from your device.',
             };
           }
           return item;

--- a/frontend/src/app/common/services/media-upload/media-upload.service.ts
+++ b/frontend/src/app/common/services/media-upload/media-upload.service.ts
@@ -208,10 +208,12 @@ export class MediaUploadService {
     // Effect to attach/detach window beforeunload listener when transfers are active
     effect(() => {
       const inProgress = this.inProgressCount();
-      if (inProgress > 0) {
-        window.addEventListener('beforeunload', this.beforeUnloadHandler);
-      } else {
-        window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      if (typeof window !== 'undefined') {
+        if (inProgress > 0) {
+          window.addEventListener('beforeunload', this.beforeUnloadHandler);
+        } else {
+          window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+        }
       }
     });
   }
@@ -474,7 +476,9 @@ export class MediaUploadService {
         },
       });
 
-    this.activeSubscriptions.set(item.id, sub);
+    if (!sub.closed) {
+      this.activeSubscriptions.set(item.id, sub);
+    }
   }
 
   private performGcsPut(

--- a/frontend/src/app/common/shared.module.ts
+++ b/frontend/src/app/common/shared.module.ts
@@ -53,6 +53,7 @@ import {GalleryCardComponent} from './components/gallery-card/gallery-card.compo
 import {StudioDropdownComponent} from './components/studio-dropdown/studio-dropdown.component';
 import {StudioSearchFilterComponent} from './components/studio-search-filter/studio-search-filter.component';
 import {StudioDateRangeFilterComponent} from './components/studio-date-range-filter/studio-date-range-filter.component';
+import {UploadProgressWidgetComponent} from './components/upload-progress-widget/upload-progress-widget.component';
 import {TruncatePipe} from './pipes/truncate.pipe';
 
 const DECLARATIONS = [
@@ -71,6 +72,7 @@ const DECLARATIONS = [
   StudioDropdownComponent,
   StudioSearchFilterComponent,
   StudioDateRangeFilterComponent,
+  UploadProgressWidgetComponent,
   TruncatePipe,
   TagsManagementDialogComponent,
 ];

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.html
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.html
@@ -119,6 +119,26 @@
               <mat-icon class="mr-1">{{ showAdvancedFilters ? 'expand_less' : 'filter_list' }}</mat-icon>
               <span>Filters</span>
             </studio-button>
+
+            <!-- Upload Media Button & Hidden Input -->
+            <input
+              #fileInput
+              type="file"
+              multiple
+              accept="image/png,video/mp4,audio/wav,audio/mpeg,audio/mp3,audio/ogg,audio/webm"
+              class="hidden"
+              (change)="onFilesSelected($event)"
+            />
+            <studio-button
+              variant="primary"
+              size="small"
+              [disabled]="uploadService.inProgressCount() > 0"
+              (click)="fileInput.click()"
+              title="Upload media files"
+            >
+              <mat-icon class="mr-1">cloud_upload</mat-icon>
+              <span>Upload Media</span>
+            </studio-button>
           </div>
 
           <!-- Select All Button -->

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.html
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.html
@@ -136,8 +136,8 @@
               (click)="fileInput.click()"
               title="Upload media files"
             >
-              <mat-icon class="mr-1">cloud_upload</mat-icon>
-              <span>Upload Media</span>
+              <mat-icon class="mr-1">add</mat-icon>
+              <span>Add to Gallery</span>
             </studio-button>
           </div>
 

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.html
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.html
@@ -133,12 +133,22 @@
               variant="primary"
               size="small"
               [disabled]="uploadService.inProgressCount() > 0"
-              (click)="fileInput.click()"
+              [matMenuTriggerFor]="uploadMenu"
               title="Upload media files"
             >
               <mat-icon class="mr-1">add</mat-icon>
               <span>Add to Gallery</span>
             </studio-button>
+            <mat-menu #uploadMenu="matMenu">
+              <button mat-menu-item class="add-to-gallery-option" (click)="fileInput.click()">
+                <mat-icon>laptop</mat-icon>
+                <span>From this device</span>
+              </button>
+              <button mat-menu-item class="add-to-gallery-option" (click)="openGoogleDrivePicker()">
+                <mat-icon svgIcon="drive-icon"></mat-icon>
+                <span>From Google Drive</span>
+              </button>
+            </mat-menu>
           </div>
 
           <!-- Select All Button -->

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.html
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.html
@@ -125,7 +125,7 @@
               #fileInput
               type="file"
               multiple
-              accept="image/png,video/mp4,audio/wav,audio/mpeg,audio/mp3,audio/ogg,audio/webm"
+              [accept]="acceptedMediaUploadFormats"
               class="hidden"
               (change)="onFilesSelected($event)"
             />

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.scss
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.scss
@@ -50,3 +50,7 @@
     background: rgba(255, 255, 255, 0.1) !important;
   }
 }
+
+.add-to-gallery-option {
+  min-width: 170px;
+}

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.spec.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.spec.ts
@@ -19,6 +19,7 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {MatIconModule} from '@angular/material/icon';
+import {MatMenuModule} from '@angular/material/menu';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {of} from 'rxjs';
 import {MediaGalleryComponent} from './media-gallery.component';
@@ -27,6 +28,7 @@ import {UserService} from '../../common/services/user.service';
 import {WorkspaceStateService} from '../../services/workspace/workspace-state.service';
 import {TagsService} from '../../common/services/tags.service';
 import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
+import {GoogleDriveService} from '../../common/services/google-drive/google-drive.service';
 
 describe('MediaGalleryComponent', () => {
   let component: MediaGalleryComponent;
@@ -36,10 +38,21 @@ describe('MediaGalleryComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [MediaGalleryComponent],
-      imports: [HttpClientTestingModule, MatIconModule, NoopAnimationsModule],
+      imports: [
+        HttpClientTestingModule,
+        MatIconModule,
+        MatMenuModule,
+        NoopAnimationsModule,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         MediaUploadService,
+        {
+          provide: GoogleDriveService,
+          useValue: {
+            openPicker: () => of([]),
+          },
+        },
         {
           provide: GalleryService,
           useValue: {
@@ -116,6 +129,17 @@ describe('MediaGalleryComponent', () => {
     } as unknown as Event;
 
     component.onFilesSelected(mockEvent);
+    expect(uploadService.uploadFiles).toHaveBeenCalledWith(1, [dummyFile]);
+  });
+
+  it('should trigger MediaUploadService.uploadFiles when files are selected from Google Drive', () => {
+    const driveService = TestBed.inject(GoogleDriveService);
+    const dummyFile = new File(['test'], 'drive-demo.png', {type: 'image/png'});
+    spyOn(driveService, 'openPicker').and.returnValue(of([dummyFile]));
+    spyOn(uploadService, 'uploadFiles');
+
+    component.openGoogleDrivePicker();
+    expect(driveService.openPicker).toHaveBeenCalled();
     expect(uploadService.uploadFiles).toHaveBeenCalledWith(1, [dummyFile]);
   });
 

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.spec.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,22 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+import {MatIconModule} from '@angular/material/icon';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {of} from 'rxjs';
 import {MediaGalleryComponent} from './media-gallery.component';
 import {GalleryService} from '../gallery.service';
-import {DomSanitizer} from '@angular/platform-browser';
-import {MatIconRegistry} from '@angular/material/icon';
 import {UserService} from '../../common/services/user.service';
-import {ElementRef, NgZone, NO_ERRORS_SCHEMA} from '@angular/core';
-import {MatIconModule} from '@angular/material/icon';
-import {of} from 'rxjs';
 import {WorkspaceStateService} from '../../services/workspace/workspace-state.service';
 import {TagsService} from '../../common/services/tags.service';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
 
 describe('MediaGalleryComponent', () => {
   let component: MediaGalleryComponent;
   let fixture: ComponentFixture<MediaGalleryComponent>;
+  let uploadService: MediaUploadService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -38,6 +39,7 @@ describe('MediaGalleryComponent', () => {
       imports: [HttpClientTestingModule, MatIconModule, NoopAnimationsModule],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
+        MediaUploadService,
         {
           provide: GalleryService,
           useValue: {
@@ -58,10 +60,9 @@ describe('MediaGalleryComponent', () => {
           useValue: {
             bypassSecurityTrustResourceUrl: (url: string) => url,
             bypassSecurityTrustUrl: (url: string) => url,
-            sanitize: (context: any, value: any) => value,
+            sanitize: (context: unknown, value: unknown) => value,
           },
         },
-
         {
           provide: UserService,
           useValue: {
@@ -95,11 +96,27 @@ describe('MediaGalleryComponent', () => {
 
     fixture = TestBed.createComponent(MediaGalleryComponent);
     component = fixture.componentInstance;
+    uploadService = TestBed.inject(MediaUploadService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should trigger MediaUploadService.uploadFiles when files are selected', () => {
+    spyOn(uploadService, 'uploadFiles');
+
+    const dummyFile = new File(['test'], 'demo.png', {type: 'image/png'});
+    const mockEvent = {
+      target: {
+        files: [dummyFile],
+        value: 'demo.png',
+      },
+    } as unknown as Event;
+
+    component.onFilesSelected(mockEvent);
+    expect(uploadService.uploadFiles).toHaveBeenCalledWith(1, [dummyFile]);
   });
 
   describe('ngOnInit filters restoration', () => {
@@ -116,7 +133,8 @@ describe('MediaGalleryComponent', () => {
       };
 
       const galleryService = TestBed.inject(GalleryService);
-      (galleryService as any).filtersState = mockState;
+      (galleryService as unknown as {filtersState: unknown}).filtersState =
+        mockState;
 
       component.ngOnInit();
 
@@ -136,7 +154,8 @@ describe('MediaGalleryComponent', () => {
 
     it('should use default values when no filtersState is stored', () => {
       const galleryService = TestBed.inject(GalleryService);
-      (galleryService as any).filtersState = null;
+      (galleryService as unknown as {filtersState: unknown}).filtersState =
+        null;
 
       component.ngOnInit();
 

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
@@ -55,6 +55,7 @@ import {TagsManagementDialogComponent} from '../../common/components/tags-manage
 import {ConfirmationDialogComponent} from '../../common/components/confirmation-dialog/confirmation-dialog.component';
 import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
 import {ACCEPTED_MEDIA_UPLOAD_FORMATS} from '../../common/services/media-upload/media-upload.constants';
+import {GoogleDriveService} from '../../common/services/google-drive/google-drive.service';
 
 @Component({
   selector: 'app-media-gallery',
@@ -216,8 +217,6 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     this.searchTerm(); // Trigger search
   }
 
-  private autoSlideIntervals: {[id: string]: any} = {};
-
   isBrowser: boolean;
 
   constructor(
@@ -232,6 +231,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     public dialog: MatDialog,
     private tagsService: TagsService,
     public uploadService: MediaUploadService,
+    private googleDriveService: GoogleDriveService,
     @Inject(PLATFORM_ID) platformId: Object,
   ) {
     this.isBrowser = isPlatformBrowser(platformId);
@@ -243,7 +243,8 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
       .addSvgIcon(
         'gemini-spark-icon',
         this.setPath(`${this.path}/gemini-spark-icon.svg`),
-      );
+      )
+      .addSvgIcon('drive-icon', this.setPath(`${this.path}/drive-icon.svg`));
     const user = this.userService.getUserDetails();
     this.userId = user?.id as number;
   }
@@ -292,7 +293,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
       if (images) {
         // Find only the new images that have been added
         const newImages = images.slice(this.images.length);
-        newImages.forEach(image => {
+        newImages.forEach(() => {
           // Intervals now handled by child component
         });
         this.images = images as GalleryItem[]; // Cast to GalleryItem[]
@@ -427,6 +428,17 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
+  openGoogleDrivePicker(): void {
+    const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+    if (workspaceId === null) return;
+
+    this.googleDriveService.openPicker().subscribe(files => {
+      if (files && files.length > 0) {
+        this.uploadService.uploadFiles(workspaceId, files);
+      }
+    });
+  }
+
   public trackByImage(index: number, image: GalleryItem): number | string {
     return `${image.itemType}:${image.id}`;
   }
@@ -442,7 +454,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   @HostListener('window:keydown.escape', ['$event'])
-  onEscapePressed(event: Event): void {
+  onEscapePressed(_event: Event): void {
     this.deselectAll();
   }
 

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
@@ -54,6 +54,7 @@ import {UserRolesEnum} from '../../common/models/user.model';
 import {TagsManagementDialogComponent} from '../../common/components/tags-management-dialog/tags-management-dialog.component';
 import {ConfirmationDialogComponent} from '../../common/components/confirmation-dialog/confirmation-dialog.component';
 import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
+import {ACCEPTED_MEDIA_UPLOAD_FORMATS} from '../../common/services/media-upload/media-upload.constants';
 
 @Component({
   selector: 'app-media-gallery',
@@ -108,6 +109,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
   images: GalleryItem[] = [];
   filteredImages: GalleryItem[] = [];
   groups: {title: string; items: GalleryItem[]}[] = [];
+  readonly acceptedMediaUploadFormats = ACCEPTED_MEDIA_UPLOAD_FORMATS;
 
   selectedItems: Set<string> = new Set();
   lastSelectedIndex: number | null = null;

--- a/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
+++ b/frontend/src/app/gallery/media-gallery/media-gallery.component.ts
@@ -1,4 +1,4 @@
-import {trigger, state, style, transition, animate} from '@angular/animations';
+import {trigger, style, transition, animate} from '@angular/animations';
 /**
  * Copyright 2025 Google LLC
  *
@@ -25,19 +25,16 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  ViewChild,
   Inject,
   PLATFORM_ID,
   HostListener,
 } from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
-import {MatCheckboxChange} from '@angular/material/checkbox';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatIconRegistry} from '@angular/material/icon';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
-import {Subscription, fromEvent, forkJoin, of} from 'rxjs';
-import {debounceTime, map, switchMap} from 'rxjs/operators';
+import {Subscription, forkJoin} from 'rxjs';
 import {MediaItemSelection} from '../../common/components/image-selector/image-selector.component';
 import {CopyToWorkspaceDialogComponent} from '../../common/components/copy-to-workspace-dialog/copy-to-workspace-dialog.component';
 import {DropdownOption} from '../../common/components/studio-dropdown/studio-dropdown.component';
@@ -56,6 +53,7 @@ import {AssignTagsDialogComponent} from '../../common/components/assign-tags-dia
 import {UserRolesEnum} from '../../common/models/user.model';
 import {TagsManagementDialogComponent} from '../../common/components/tags-management-dialog/tags-management-dialog.component';
 import {ConfirmationDialogComponent} from '../../common/components/confirmation-dialog/confirmation-dialog.component';
+import {MediaUploadService} from '../../common/services/media-upload/media-upload.service';
 
 @Component({
   selector: 'app-media-gallery',
@@ -129,6 +127,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
   private allImagesLoadedSubscription: Subscription | undefined;
   private loadingSubscription: Subscription | undefined;
   private resizeSubscription: Subscription | undefined;
+  private uploadBatchSubscription: Subscription | undefined;
   private _hostVisibilityObserver!: IntersectionObserver;
   private _scrollObserver!: IntersectionObserver;
   public userEmailFilter = '';
@@ -230,6 +229,7 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     private snackBar: MatSnackBar,
     public dialog: MatDialog,
     private tagsService: TagsService,
+    public uploadService: MediaUploadService,
     @Inject(PLATFORM_ID) platformId: Object,
   ) {
     this.isBrowser = isPlatformBrowser(platformId);
@@ -301,6 +301,11 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     this.allImagesLoadedSubscription =
       this.galleryService.allImagesLoaded.subscribe(loaded => {
         this.allImagesLoaded = loaded;
+      });
+
+    this.uploadBatchSubscription =
+      this.uploadService.uploadBatchComplete$.subscribe(() => {
+        this.searchTerm();
       });
 
     if (this.isBrowser) {
@@ -404,8 +409,20 @@ export class MediaGalleryComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     this.resizeSubscription?.unsubscribe();
+    this.uploadBatchSubscription?.unsubscribe();
     this._hostVisibilityObserver?.disconnect();
     this._scrollObserver?.disconnect();
+  }
+
+  onFilesSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      const workspaceId = this.workspaceStateService.getActiveWorkspaceId();
+      if (workspaceId !== null) {
+        this.uploadService.uploadFiles(workspaceId, Array.from(input.files));
+      }
+      input.value = '';
+    }
   }
 
   public trackByImage(index: number, image: GalleryItem): number | string {

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -85,6 +85,7 @@ describe('HomeComponent', () => {
     mockWorkspaceStateService = jasmine.createSpyObj('WorkspaceStateService', [
       'getActiveWorkspaceId',
     ]);
+    mockWorkspaceStateService.getActiveWorkspaceId.and.returnValue(1);
     mockRouter = jasmine.createSpyObj('Router', [
       'navigate',
       'getCurrentNavigation',

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -49,6 +49,8 @@
     <link rel="preconnect" href="https://storage.googleapis.com" />
     <!-- For Google Identity Services (GIS) libary to allow Google Identity Platform -->
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <!-- For Google Drive Picker -->
+    <script src="https://apis.google.com/js/api.js" async defer></script>
   </head>
   <body class="mat-typography">
     <app-root></app-root>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -496,3 +496,8 @@ app-workspace-switcher .workspace-name {
     font-weight: 600;
   }
 }
+
+.google-drive-snackbar {
+  --mdc-snackbar-container-color: #000000;
+  --mdc-snackbar-supporting-text-color: #ffffff;
+}


### PR DESCRIPTION
Fixes [#517982291](https://b.corp.google.com/u/1/issues/517982291)

# Multi-file Upload

Implement a high-performance, resilient **Multi-File Upload System** for the **Media Gallery** in Creative Studio. The feature enables users to select and upload multiple media assets (images, videos, audio) simultaneously. 

Visually, an active **floating progress widget/tooltip** tracks individual and overall file upload progress in real time. The upload workflow follows the **GCS Direct Signed URL Strategy** used in the Brand Guidelines feature to maximize upload speed and reduce server load.

Key Requirements:
1. **Multi-File Upload Button in Media Gallery**: Add a new primary action button in the Media Gallery toolbar allowing batch selection of images, videos, and audio files.
2. **GCS Direct Signed URL Architecture & Supported Image Formats**: 
   - Supported image formats are: `image/png`, `image/jpeg`, `image/webp`, `image/heic`, `image/heif`, and `.avif` (`image/avif`).
   - For `image/png`, `image/jpeg`, and `image/webp` formats, follow the direct upload implementation (`initiate-upload` signed URL -> direct GCS PUT HTTP request -> `finalize-upload`).
   - For `avif`, `heif`, and `heic` formats, the frontend must convert each file to PNG *before* proceeding with the signed URL upload workflow by calling the `/api/source_assets/convert-to-png` endpoint (which is already implemented and used for the "Upload New" button).
   - Because `/api/source_assets/convert-to-png` currently does not support `heic` or `heif` formats, upgrade the backend endpoint (e.g., by adding HEIF/HEIC decoding support to Pillow via `pillow-heif` library) so that `convert_to_png` can process `heic` and `heif` files.
3. **Concurrency Capped at 5 Files Simultaneously**:
   - The frontend `MediaUploadService` strictly limits active simultaneous uploads to **maximum 5 files at the same time**.
   - If more than 5 files are selected (e.g. 12 files), the first 5 start uploading immediately in parallel while the remaining 7 stay in `QUEUED` state. As each transfer completes or fails, the next queued file automatically begins processing.
4. **Floating Progress Tooltip/Widget**: Create an active floating widget rendered at the app layout level ([app.component.html](~/code/gcc-creative-studio/frontend/src/app/app.component.html)) that displays batch progress, individual file statuses, transfer rates, and completion/error indicators. The overall batch progress percentage and progress bar calculation must **exclude failed (`FAILED`) and cancelled (`CANCELLED`) files** (calculating progress only across active, queued, and successfully completed files).
5. **Header Indicators for Success & Failures**: Tooltip header displays summary counters for **total files uploaded** (successful count) and **total failed indicator** (failed count).
6. **Smart Close Button & Queue Clearing**:
   - Include a Close Button (`close` icon).
   - **Disabled** while at least one file is currently in progress (`GENERATING_URL` or `UPLOADING`).
   - **Enabled** once all files in the batch are finished (either completed or failed).
   - Clicking Close clears the upload list/queue from memory and `sessionStorage`.
7. **Filename Status Visibility & Re-login / Reload Persistence**:
   - Display success or failed filenames explicitly in the list so users can immediately identify which files need to be re-uploaded.
   - Preserve completed and failed upload states in `sessionStorage` so if a user reloads or re-logins, failed filenames and status indicators are retained and visible.
8. **Minimize & Maximize Controls**: Support collapsing the tooltip into a compact floating status pill/badge or expanding it to full detail mode without interrupting active transfers.
9. **Route Navigation Persistence**: Upload jobs remain active and visible in the floating widget while the user navigates across different views and routes within the web application.
10. **Tab Unload Protection**: Register a `beforeunload` window listener while uploads are in progress to warn users before closing or refreshing the tab.
11. **Individual Item Upload Cancellation**: Provide a cancel action button (`close` / `cancel` icon) on each uncompleted file item (statuses `QUEUED`, `GENERATING_URL`, or `UPLOADING`). Cancelling an in-progress upload aborts the HTTP request, sets item status to `CANCELLED`, and releases the concurrency pool slot so the next queued file starts immediately.

## Screenshot

<img width="1413" height="847" alt="image" src="https://github.com/user-attachments/assets/4b4d4fff-f5f9-449b-9e36-608f722f9054" />

<img width="512" height="322" alt="image" src="https://github.com/user-attachments/assets/5880451c-4c35-483a-a161-cd14dac9be4a" />


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

## Additional fixes

* Disabled state for studio-button component was not working as expected

# Google Drive file picker implementation

Implement **Google Drive file upload integration** within the **Media Gallery** of the Google Cloud Creative Studio Platform. 

Currently, users can upload files from their local machine via the **"Add to Gallery"** button, which directly triggers a browser file input and initiates a multi-file direct-to-GCS upload workflow managed by the `MediaUploadService`. 

This task modifies the existing **"Add to Gallery"** button into a dropdown menu while preserving its `studio-button` component styling. When clicked, the button opens a menu (`mat-menu`) presenting two upload sources:
1. **"From this device"**: Opens the standard local machine file browser (`<input type="file">`).
2. **"From Google Drive"**: Launches the Google Drive Picker dialog.

When users browse and select media assets (images, videos, audio) from their Google Drive using the **Google Picker API**, the client fetches the file contents from Google Drive, constructs standard browser `File` objects, and submits them to `MediaUploadService.uploadFiles()`. This guarantees that **files selected from Google Drive are uploaded through the exact same workflow as local PC uploads**—including concurrency throttling (max 5 concurrent uploads), GCS signed URL direct PUT requests, floating progress widget tracking, HEIC/AVIF to PNG pre-conversion, and automatic gallery reloads.

### Key Requirements & Design Decisions:
1. **"Add to Gallery" Dropdown Button**: Modify the existing "Add to Gallery" toolbar button (`<studio-button>`) to attach a dropdown menu (`[matMenuTriggerFor]="uploadMenu"`). Keep exact `studio-button` styles and disabled state when uploads are in progress.
2. **Dropdown Menu Options (`mat-menu`)**:
   - **From this device**: Includes a computer/device icon and triggers `fileInput.click()`.
   - **From Google Drive**: Reuses the existing `drive-icon.svg` registered via `MatIconRegistry` and triggers `openGoogleDrivePicker()`.
3. **Google Picker API & GIS Integration**: Integrate Google Identity Services (GIS) token client for incremental OAuth 2.0 authorization (`https://www.googleapis.com/auth/drive.readonly` scope) and open the interactive Google Picker dialog for media file selection.
4. **Modal Background Click & Scroll Jumping Prevention**:
   - Enable backdrop click closing on the Google Picker modal dialog so clicking outside the dialog dismisses it cleanly.
   - Prevent scroll position jumping when the modal opens by explicitly maintaining/resetting scroll position to `top: 0` (`window.scrollTo({ top: 0, behavior: 'instant' })`).
5. **Continuous File Download Loading Feedback**: Display a visible, indeterminate loading toast notification via `MatSnackBar` (`"Downloading <filename> from Google Drive..."` or batch indicator) immediately when *any* file is being downloaded from Google Drive into browser memory, dismissing the loader as soon as the files are ready for `MediaUploadService`.
6. **Seamless Workflow Parity**: Download selected Google Drive files into browser memory as Blob/File objects and feed them directly into `MediaUploadService.uploadFiles(workspaceId, files)`.
7. **Zero Backend Protocol Changes**: By converting Drive files into client-side `File` objects before upload, no modifications are required to the core upload architecture (`/generate-upload-url`, GCS PUT, and `/finalize-upload`).

## Screenshots

<img width="1393" height="876" alt="image" src="https://github.com/user-attachments/assets/ddb545de-6eee-49ef-af58-f3c36ebe0695" />

<img width="1393" height="876" alt="image" src="https://github.com/user-attachments/assets/caefb7eb-c9fb-4ae9-bb50-c27f9d56ed38" />
