### PR TITLE
feat: implement workflow node for Image Upscale and some minor bug fixed

### DIFF
--- a/backend/src/workflows/schema/workflow_model.py
+++ b/backend/src/workflows/schema/workflow_model.py
@@ -44,6 +44,7 @@ class NodeTypes(str, Enum):
     CROP_IMAGE = "crop_image"
     VIRTUAL_TRY_ON = "virtual_try_on"
     GENERATE_AUDIO = "generate_audio"
+    UPSCALE_IMAGE = "upscale_image"
 
 
 # =========================================
@@ -266,6 +267,24 @@ class GenerateAudioStep(BaseStep[GenerateAudioInputs, GenerateAudioSettings]):
     settings: GenerateAudioSettings
 
 
+# --- Upscale Image ---
+class UpscaleImageInputs(BaseModel):
+    input_image: WorkflowInputItem
+
+
+class UpscaleImageSettings(BaseModel):
+    model: str = "imagen-4-upscale-preview"
+    upscale_factor: Literal["x2", "x3", "x4"] = "x2"
+    enhance_input_image: bool = False
+    image_preservation_factor: float | None = None
+
+
+class UpscaleImageStep(BaseStep[UpscaleImageInputs, UpscaleImageSettings]):
+    type: Literal[NodeTypes.UPSCALE_IMAGE] = NodeTypes.UPSCALE_IMAGE
+    inputs: UpscaleImageInputs
+    settings: UpscaleImageSettings = Field(default_factory=UpscaleImageSettings)
+
+
 # =========================================
 # Workflow Step Union
 # =========================================
@@ -278,6 +297,7 @@ WorkflowStepUnion = Union[
     GenerateVideoStep,
     VirtualTryOnStep,
     GenerateAudioStep,
+    UpscaleImageStep,
 ]
 
 # Discriminated union based on the 'type' field in each step

--- a/backend/src/workflows_executor/dto/workflows_executor_dto.py
+++ b/backend/src/workflows_executor/dto/workflows_executor_dto.py
@@ -25,6 +25,8 @@ from src.workflows.schema.workflow_model import (
     GenerateTextSettings,
     GenerateVideoInputs,
     GenerateVideoSettings,
+    UpscaleImageInputs,
+    UpscaleImageSettings,
     VirtualTryOnInputs,
     VirtualTryOnSettings,
 )
@@ -45,6 +47,12 @@ class EditImageRequest(BaseModel):
     workspace_id: int
     inputs: EditImageInputs
     config: EditImageSettings
+
+
+class UpscaleImageRequest(BaseModel):
+    workspace_id: int
+    inputs: UpscaleImageInputs
+    config: UpscaleImageSettings
 
 
 class GenerateVideoRequest(BaseModel):

--- a/backend/src/workflows_executor/workflows_executor_controller.py
+++ b/backend/src/workflows_executor/workflows_executor_controller.py
@@ -22,6 +22,7 @@ from src.workflows_executor.dto.workflows_executor_dto import (
     GenerateImageRequest,
     GenerateTextRequest,
     GenerateVideoRequest,
+    UpscaleImageRequest,
     VirtualTryOnRequest,
 )
 from src.workflows_executor.workflows_executor_service import (
@@ -60,6 +61,15 @@ async def edit_image(
     service: WorkflowsExecutorService = Depends(),
 ):
     return await service.edit_image(request, authorization)
+
+
+@router.post("/upscale_image")
+async def upscale_image(
+    request: UpscaleImageRequest,
+    authorization: Annotated[str | None, Header()] = None,
+    service: WorkflowsExecutorService = Depends(),
+):
+    return await service.upscale_image(request, authorization)
 
 
 @router.post("/generate_video")

--- a/backend/src/workflows_executor/workflows_executor_service.py
+++ b/backend/src/workflows_executor/workflows_executor_service.py
@@ -29,6 +29,7 @@ from src.workflows_executor.dto.workflows_executor_dto import (
     GenerateImageRequest,
     GenerateTextRequest,
     GenerateVideoRequest,
+    UpscaleImageRequest,
     VirtualTryOnRequest,
 )
 
@@ -602,3 +603,68 @@ class WorkflowsExecutorService:
         await self._poll_job_status(audio_id, authorization)
 
         return {"generated_audio": audio_id}
+
+    async def upscale_image(
+        self,
+        request: UpscaleImageRequest,
+        authorization: str | None = None,
+    ):
+        logger.info("Upscale image execution")
+        media_items, asset_ids = self._normalize_asset_inputs(
+            request.inputs.input_image,
+        )
+
+        source_asset_id = asset_ids[0] if asset_ids else None
+        media_item_id = media_items[0]["media_item_id"] if media_items else None
+
+        if not source_asset_id and not media_item_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Input image is required for Image Upscaling",
+            )
+
+        url = self.backend_url + "/api/images/upload-upscale"
+        headers = {"Authorization": authorization} if authorization else {}
+
+        data = {
+            "workspaceId": str(request.workspace_id),
+        }
+        if source_asset_id:
+            data["id"] = str(source_asset_id)
+        if media_item_id:
+            data["mediaItemId"] = str(media_item_id)
+        if request.config.upscale_factor:
+            data["upscaleFactor"] = request.config.upscale_factor
+        if request.config.enhance_input_image is not None:
+            data["enhance_input_image"] = str(
+                request.config.enhance_input_image
+            ).lower()
+        if request.config.image_preservation_factor is not None:
+            data["image_preservation_factor"] = str(
+                request.config.image_preservation_factor
+            )
+
+        logger.info(
+            f"Call backend with url: {url}, data: {data}, headers: {headers}"
+        )
+
+        response = await self.rest_client.post(url, data=data, headers=headers)
+
+        if response.status_code != 200:
+            logger.error("Backend error: %s", response.text)
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"Backend error: {response.text}",
+            )
+
+        dict_response = response.json()
+        upscaled_id = dict_response.get("id", None)
+        if not upscaled_id:
+            raise HTTPException(
+                status_code=500, detail="Couldn't create upscale job"
+            )
+
+        # Poll for completion
+        await self._poll_job_status(upscaled_id, authorization)
+
+        return {"upscaled_image": upscaled_id}

--- a/backend/tests/workflows_executor/test_workflows_executor_service.py
+++ b/backend/tests/workflows_executor/test_workflows_executor_service.py
@@ -335,3 +335,51 @@ async def test_generate_audio(service):
         assert result["generated_audio"] == 555
         service.mock_rest_client.post.assert_called_once()
         mock_poll.assert_called_once_with(555, None)
+
+
+@pytest.mark.anyio
+async def test_upscale_image_success(service):
+    request = MagicMock()
+    request.workspace_id = 1
+    request.inputs.input_image = 123
+    request.config.upscale_factor = "x4"
+    request.config.enhance_input_image = True
+    request.config.image_preservation_factor = 0.8
+
+    service.mock_rest_client.post.return_value = Response(200, json={"id": 444})
+
+    with (
+        patch.object(
+            service,
+            "_normalize_asset_inputs",
+            return_value=([{"media_item_id": 123}], []),
+        ),
+        patch.object(
+            service,
+            "_poll_job_status",
+            AsyncMock(return_value=True),
+        ) as mock_poll,
+    ):
+        result = await service.upscale_image(request)
+        assert result["upscaled_image"] == 444
+        service.mock_rest_client.post.assert_called_once()
+        mock_poll.assert_called_once_with(444, None)
+
+
+@pytest.mark.anyio
+async def test_upscale_image_missing_input(service):
+    request = MagicMock()
+    request.workspace_id = 1
+    request.inputs.input_image = None
+    request.config.upscale_factor = "x2"
+    request.config.enhance_input_image = None
+    request.config.image_preservation_factor = None
+
+    with patch.object(
+        service,
+        "_normalize_asset_inputs",
+        return_value=([], []),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await service.upscale_image(request)
+        assert exc.value.status_code == 400

--- a/frontend/src/app/common/components/studio-slider/studio-slider.component.html
+++ b/frontend/src/app/common/components/studio-slider/studio-slider.component.html
@@ -14,7 +14,7 @@
  limitations under the License.
 -->
 
-<div class="studio-slider-container w-full">
+<div class="studio-slider-container w-full" (mousedown)="$event.stopPropagation()" (pointerdown)="$event.stopPropagation()">
   <div class="flex justify-between items-center mb-1 text-sm text-gray-300 w-full" *ngIf="label || valueText">
     <span class="font-medium" *ngIf="label">{{ label }}</span>
     <span *ngIf="valueText">{{ valueText }}</span>
@@ -25,6 +25,8 @@
     [step]="step"
     [disabled]="disabled"
     class="studio-slider py-2 !w-full"
+    (mousedown)="$event.stopPropagation()"
+    (pointerdown)="$event.stopPropagation()"
   >
     <input matSliderThumb [(ngModel)]="value" (ngModelChange)="onModelChange($event)" />
   </mat-slider>

--- a/frontend/src/app/workflows/shared/step-configs.map.ts
+++ b/frontend/src/app/workflows/shared/step-configs.map.ts
@@ -20,6 +20,7 @@ import {GENERATE_AUDIO_STEP_CONFIG} from '../workflow-editor/step-components/ste
 import {GENERATE_IMAGE_STEP_CONFIG} from '../workflow-editor/step-components/step-configs/generate-image-step.config';
 import {GENERATE_TEXT_STEP_CONFIG} from '../workflow-editor/step-components/step-configs/generate-text-step.config';
 import {GENERATE_VIDEO_STEP_CONFIG} from '../workflow-editor/step-components/step-configs/generate-video-step.config';
+import {UPSCALE_IMAGE_STEP_CONFIG} from '../workflow-editor/step-components/step-configs/upscale-image-step.config';
 import {VIRTUAL_TRY_ON_STEP_CONFIG} from '../workflow-editor/step-components/step-configs/virtual-try-on-step.config';
 import {NodeTypes} from '../workflow.models';
 
@@ -31,4 +32,5 @@ export const STEP_CONFIGS_MAP = {
   [NodeTypes.GENERATE_VIDEO]: GENERATE_VIDEO_STEP_CONFIG,
   [NodeTypes.VIRTUAL_TRY_ON]: VIRTUAL_TRY_ON_STEP_CONFIG,
   [NodeTypes.GENERATE_AUDIO]: GENERATE_AUDIO_STEP_CONFIG,
+  [NodeTypes.UPSCALE_IMAGE]: UPSCALE_IMAGE_STEP_CONFIG,
 };

--- a/frontend/src/app/workflows/workflow-editor/add-step-modal/add-step-modal.component.scss
+++ b/frontend/src/app/workflows/workflow-editor/add-step-modal/add-step-modal.component.scss
@@ -44,6 +44,8 @@ mat-dialog-content {
   max-height: 60vh;
   min-height: 300px; /* Force at least some height to see if it renders */
   padding: 0 24px 24px 24px !important; // Override default material padding if needed
+  overflow: hidden;
+  margin-bottom: 16px;
 }
 
 .node-grid {

--- a/frontend/src/app/workflows/workflow-editor/add-step-modal/add-step-modal.component.spec.ts
+++ b/frontend/src/app/workflows/workflow-editor/add-step-modal/add-step-modal.component.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatDialogRef} from '@angular/material/dialog';
+import {AddStepModalComponent} from './add-step-modal.component';
+
+describe('AddStepModalComponent', () => {
+  let component: AddStepModalComponent;
+  let fixture: ComponentFixture<AddStepModalComponent>;
+  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<AddStepModalComponent>>;
+
+  beforeEach(async () => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      declarations: [AddStepModalComponent],
+      providers: [{provide: MatDialogRef, useValue: dialogRefSpy}],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddStepModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should include upscale_image in stepTypes', () => {
+    const upscaleOption = component.stepTypes.find(
+      s => s.type === 'upscale_image',
+    );
+    expect(upscaleOption).toBeDefined();
+    expect(upscaleOption?.label).toBe('Image Upscaler');
+  });
+
+  it('should close dialog with selected step type', () => {
+    component.selectStep('upscale_image');
+    expect(dialogRefSpy.close).toHaveBeenCalledWith('upscale_image');
+  });
+
+  it('should close dialog without value on closeModal', () => {
+    component.closeModal();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith();
+  });
+});

--- a/frontend/src/app/workflows/workflow-editor/add-step-modal/add-step-modal.component.ts
+++ b/frontend/src/app/workflows/workflow-editor/add-step-modal/add-step-modal.component.ts
@@ -70,6 +70,13 @@ export class AddStepModalComponent {
       description: 'Generates audio (music or speech) from a text prompt.',
       icon: 'music_note',
     },
+    {
+      type: 'upscale_image',
+      label: 'Image Upscaler',
+      description:
+        'Upscales image resolution by 2x, 3x, or 4x using Imagen AI.',
+      icon: 'high_quality',
+    },
   ];
 
   constructor(public dialogRef: MatDialogRef<AddStepModalComponent>) {}

--- a/frontend/src/app/workflows/workflow-editor/step-components/generic-step/generic-step.component.html
+++ b/frontend/src/app/workflows/workflow-editor/step-components/generic-step/generic-step.component.html
@@ -92,7 +92,7 @@
           <div *ngIf="setting.type === 'checkbox'" class="checkbox-group">
             <mat-checkbox [formControlName]="setting.name">{{ setting.label }}</mat-checkbox>
           </div>
-          <div *ngIf="setting.type === 'slider'" class="slider-group">
+          <div *ngIf="setting.type === 'slider'" class="slider-group" (mousedown)="$event.stopPropagation()" (pointerdown)="$event.stopPropagation()">
             <studio-slider
               label="{{ setting.label }}"
               [valueText]="stepForm.get('settings')?.get(setting.name)?.value"

--- a/frontend/src/app/workflows/workflow-editor/step-components/generic-step/generic-step.component.scss
+++ b/frontend/src/app/workflows/workflow-editor/step-components/generic-step/generic-step.component.scss
@@ -138,6 +138,7 @@
 
   .step-title {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 12px;
     font-size: 16px;
@@ -312,4 +313,8 @@
   0% { box-shadow: 0 0 10px 2px #4ade80, 0 10px 30px rgba(0, 0, 0, 0.3); }
   50% { box-shadow: 0 0 20px 6px #4ade80, 0 10px 30px rgba(0, 0, 0, 0.3); }
   100% { box-shadow: 0 0 10px 2px #4ade80, 0 10px 30px rgba(0, 0, 0, 0.3); }
+}
+
+.step-actions {
+  display: flex;
 }

--- a/frontend/src/app/workflows/workflow-editor/step-components/step-configs/upscale-image-step.config.ts
+++ b/frontend/src/app/workflows/workflow-editor/step-components/step-configs/upscale-image-step.config.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {StepConfig} from '../generic-step/step.model';
+
+const UPSCALE_FACTORS = [
+  {value: 'x2', label: '2x (Double Resolution)'},
+  {value: 'x3', label: '3x (Triple Resolution)'},
+  {value: 'x4', label: '4x (Quadruple Resolution)'},
+];
+
+export const UPSCALE_IMAGE_STEP_CONFIG: StepConfig = {
+  type: 'upscale_image',
+  title: 'Image Upscaler',
+  icon: 'high_quality',
+  inputs: [
+    {
+      name: 'input_image',
+      label: 'Input Image',
+      type: 'image',
+      required: true,
+    },
+  ],
+  settings: [
+    {
+      name: 'upscale_factor',
+      label: 'Upscale Factor',
+      type: 'select',
+      options: UPSCALE_FACTORS,
+      defaultValue: 'x2',
+    },
+    {
+      name: 'enhance_input_image',
+      label: 'Enhance Input Image',
+      type: 'checkbox',
+      defaultValue: false,
+    },
+    {
+      name: 'image_preservation_factor',
+      label: 'Image Preservation Factor',
+      type: 'slider',
+      defaultValue: null,
+      min: 0,
+      max: 1,
+      step: 0.05,
+    },
+  ],
+  outputs: [
+    {
+      name: 'upscaled_image',
+      label: 'upscaled_image',
+      type: 'image',
+    },
+  ],
+};

--- a/frontend/src/app/workflows/workflow.models.ts
+++ b/frontend/src/app/workflows/workflow.models.ts
@@ -23,6 +23,7 @@ export enum NodeTypes {
   CROP_IMAGE = 'crop_image',
   VIRTUAL_TRY_ON = 'virtual_try_on',
   GENERATE_AUDIO = 'generate_audio',
+  UPSCALE_IMAGE = 'upscale_image',
 }
 
 export interface StepOutputReference {


### PR DESCRIPTION
Fixes #N/A

Implement a new **Image Upscaler (`upscale_image`) Workflow Node** across the **Google Cloud Creative Studio Platform** backend and frontend.

Currently, the Workflow Engine allows users to chain generative AI operations such as text generation (`generate_text`), image generation (`generate_image`), image editing (`edit_image`), virtual try-on (`virtual_try_on`), video generation (`generate_video`), and audio generation (`generate_audio`). However, users cannot currently upscale low-resolution or intermediate workflow-generated images within an automated workflow pipeline.

This task integrates **Image Upscaling (`upscale_image`)** as a first-class workflow step in both the Python backend and the Angular workflow canvas:

1. **Workflow Definition & Pydantic Schemas**: Add `NodeTypes.UPSCALE_IMAGE` (`upscale_image`), step inputs (`UpscaleImageInputs`), settings (`UpscaleImageSettings` including `upscale_factor`, `enhance_input_image`, and `image_preservation_factor`), and output references to the backend workflow models.
2. **GCP Workflow Orchestration Compilation**: Ensure the topological sorting and GCP Workflows YAML generator in `WorkflowService` seamlessly maps `upscale_image` steps to invoke `http.post` against the Workflows Executor URL (`/api/workflows-executor/upscale_image`).
3. **Workflows Executor Service & Controller**: Implement the `POST /api/workflows-executor/upscale_image` endpoint in `WorkflowsExecutorService` to resolve input media assets/references, initiate the Imagen 4 upscale job via the internal image service with preservation factor and enhancement settings, poll for completion, and return the upscaled media ID as output (`upscaled_image`).
4. **Angular Workflow Canvas UI & Palette**: Add the `Image Upscaler` node to the `AddStepModalComponent` palette, configure the step definition schema (`UPSCALE_IMAGE_STEP_CONFIG`) with upscale factor (`x2`, `x3`, `x4`), image enhancement checkbox, and image preservation factor slider (`image_preservation_factor`), and register it in `STEP_CONFIGS_MAP`.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

# Bug fixes

* Wrap missing when chip is showing

Before:

<img width="448" height="177" alt="image" src="https://github.com/user-attachments/assets/567c2bfd-9c06-41d4-b3f6-233d134c911d" />


After:

<img width="447" height="167" alt="image" src="https://github.com/user-attachments/assets/ca5fb018-75dd-4b53-89ec-bab7549428c2" />

* Dragging step was not possible:

<img width="442" height="156" alt="image" src="https://github.com/user-attachments/assets/96fdd161-dde9-4741-b264-47cae6c659ad" />
