### PR TITLE
Fix: Nano Banana 2 Lite enabled for Video to image and 10 sec for Omni video generation

### DIFF
--- a/backend/src/multimodal/gemini_service.py
+++ b/backend/src/multimodal/gemini_service.py
@@ -219,12 +219,11 @@ class GeminiService:
             if value:  # Ensure value is not None or empty
                 formatted_key = key.replace("_", " ").title()
                 if key == "aspect_ratio":
-                    if value == "9:16":
-                        formatted_value = "9:16 (Portrait / Vertical format)"
-                    elif value == "16:9":
-                        formatted_value = "16:9 (Landscape / Widescreen format)"
-                    else:
-                        formatted_value = str(value)
+                    ratio_labels = {
+                        "9:16": "9:16 (Portrait / Vertical format)",
+                        "16:9": "16:9 (Landscape / Widescreen format)",
+                    }
+                    formatted_value = ratio_labels.get(value, str(value))
                 else:
                     formatted_value = str(value)
                 attributes.append(f"- {formatted_key}: {formatted_value}")

--- a/backend/src/multimodal/rewriters.py
+++ b/backend/src/multimodal/rewriters.py
@@ -166,7 +166,7 @@ Example of a General Prompt for you to replace with the information received:
   }
 }
 
-IMPORTANT!! Example 3 of prompts if no styling properties ('style', 'color_and_tone', 'lighting' and 'composition') received or empty then 'visual_style' should return emtpy:
+IMPORTANT!! Example 3 of prompts if no styling properties ('style', 'color_and_tone', 'lighting' and 'composition') received or empty then 'visual_style' should return empty:
 {
   "metadata": {
     "prompt_name": "Abstract Landscape",
@@ -387,7 +387,7 @@ Example 3 of prompts (Vertical 9:16 video for Gemini Omni Flash):
 }
 
 
-Example 4 of prompts if no styling properties ('style', 'color_and_tone', 'lighting' and 'composition') received or empty then 'visual_style' should return emtpy:
+Example 4 of prompts if no styling properties ('style', 'color_and_tone', 'lighting' and 'composition') received or empty then 'visual_style' should return empty:
 {
   "metadata": {
     "prompt_name": "Simple Scene",

--- a/backend/src/videos/dto/create_veo_dto.py
+++ b/backend/src/videos/dto/create_veo_dto.py
@@ -110,8 +110,8 @@ class CreateVeoDto(BaseDto):
     duration_seconds: int = Field(
         default=8,
         ge=1,
-        le=8,
-        description="Duration in seconds for the videos to generate (between 1 and 8 secs).",
+        le=10,
+        description="Duration in seconds for the videos to generate (between 1 and 10 secs).",
     )
     start_image_asset_id: AssetReferenceDto | None = Field(
         default=None,

--- a/backend/src/videos/dto/create_veo_dto.py
+++ b/backend/src/videos/dto/create_veo_dto.py
@@ -169,6 +169,8 @@ class CreateVeoDto(BaseDto):
         1. Ensures that source_media_items have a valid role.
         2. Ensures references are not used with start/end frames or source videos.
         3. Ensures reference image roles are only used with correct model.
+        4. Validates model-specific resolution limits.
+        5. Validates model-specific duration limits.
         """
         conflicting_roles_present = False
         reference_roles_present = False
@@ -252,6 +254,20 @@ class CreateVeoDto(BaseDto):
             raise ValueError(
                 f"Model '{model.value}' does not support resolution '{self.resolution}'. "
                 f"Supported resolutions: {sorted(list(allowed_resolutions))}"
+            )
+
+        # Validate model-specific duration limits
+        max_duration = 8
+        if model in (
+            GenerationModelEnum.GEMINI_OMNI,
+            GenerationModelEnum.GEMINI_OMNI_FLASH_PREVIEW,
+        ):
+            max_duration = 10
+
+        if self.duration_seconds > max_duration:
+            raise ValueError(
+                f"Model '{model.value}' does not support duration '{self.duration_seconds}s'. "
+                f"Maximum supported duration: {max_duration}s."
             )
 
         return self

--- a/backend/src/videos/veo_service.py
+++ b/backend/src/videos/veo_service.py
@@ -641,6 +641,16 @@ def _process_video_in_background(
                             permanent_thumbnail_gcs_uris = []
                             interaction_details = []
 
+                            duration_str = (
+                                f"{request_dto.duration_seconds}s"
+                                if request_dto.duration_seconds
+                                else "8s"
+                            )
+                            omni_response_format = {
+                                "type": "video",
+                                "duration": duration_str,
+                            }
+
                             num_outputs = 1
                             worker_logger.info(
                                 "Queueing %s Gemini Omni generation interactions.",
@@ -659,12 +669,14 @@ def _process_video_in_background(
                                                 model=model_name_for_api,
                                                 previous_interaction_id=interaction1_id,
                                                 input=turn2_input,
+                                                response_format=omni_response_format,
                                             )
                                         else:
                                             interaction = await asyncio.to_thread(
                                                 vertex_client.interactions.create,
                                                 model=model_name_for_api,
                                                 input=t1_inputs,
+                                                response_format=omni_response_format,
                                             )
                                         break
                                     except Exception as e:

--- a/backend/tests/videos/test_create_veo_dto.py
+++ b/backend/tests/videos/test_create_veo_dto.py
@@ -172,14 +172,43 @@ def test_validate_resolution_by_model():
 
 
 def test_validate_duration_seconds():
-    # 10s is valid (e.g. for Gemini Omni)
-    dto = CreateVeoDto(
+    # 10s is valid for Gemini Omni Flash Preview
+    dto_flash = CreateVeoDto(
         prompt="Test",
         workspace_id=1,
         generation_model=GenerationModelEnum.GEMINI_OMNI_FLASH_PREVIEW,
         duration_seconds=10,
     )
-    assert dto.duration_seconds == 10
+    assert dto_flash.duration_seconds == 10
+
+    # 10s is valid for Gemini Omni
+    dto_omni = CreateVeoDto(
+        prompt="Test",
+        workspace_id=1,
+        generation_model=GenerationModelEnum.GEMINI_OMNI,
+        duration_seconds=10,
+    )
+    assert dto_omni.duration_seconds == 10
+
+    # 8s is valid for Veo models
+    dto_veo = CreateVeoDto(
+        prompt="Test",
+        workspace_id=1,
+        generation_model=GenerationModelEnum.VEO_3_1_GENERATE_001,
+        duration_seconds=8,
+    )
+    assert dto_veo.duration_seconds == 8
+
+    # 10s is invalid for Veo models (max 8s)
+    with pytest.raises(ValidationError) as exc_info:
+        CreateVeoDto(
+            prompt="Test",
+            workspace_id=1,
+            generation_model=GenerationModelEnum.VEO_3_1_GENERATE_001,
+            duration_seconds=10,
+        )
+    assert "does not support duration '10s'" in str(exc_info.value)
+    assert "Maximum supported duration: 8s" in str(exc_info.value)
 
     # 11s exceeds max limit
     with pytest.raises(ValidationError) as exc_info:

--- a/backend/tests/videos/test_create_veo_dto.py
+++ b/backend/tests/videos/test_create_veo_dto.py
@@ -169,3 +169,24 @@ def test_validate_resolution_by_model():
         generation_model=GenerationModelEnum.VEO_3_1_GENERATE_001,
         resolution="4K",
     )
+
+
+def test_validate_duration_seconds():
+    # 10s is valid (e.g. for Gemini Omni)
+    dto = CreateVeoDto(
+        prompt="Test",
+        workspace_id=1,
+        generation_model=GenerationModelEnum.GEMINI_OMNI_FLASH_PREVIEW,
+        duration_seconds=10,
+    )
+    assert dto.duration_seconds == 10
+
+    # 11s exceeds max limit
+    with pytest.raises(ValidationError) as exc_info:
+        CreateVeoDto(
+            prompt="Test",
+            workspace_id=1,
+            generation_model=GenerationModelEnum.GEMINI_OMNI_FLASH_PREVIEW,
+            duration_seconds=11,
+        )
+    assert "less than or equal to 10" in str(exc_info.value)

--- a/backend/tests/videos/test_veo_service.py
+++ b/backend/tests/videos/test_veo_service.py
@@ -1353,6 +1353,11 @@ class TestBackgroundWorkers:
 
             mock_media_repo.update.assert_called_once()
             mock_vertex_client.interactions.create.assert_called_once()
+            call_kwargs = mock_vertex_client.interactions.create.call_args[1]
+            assert call_kwargs["response_format"] == {
+                "type": "video",
+                "duration": "5s",
+            }
 
     @patch("src.database.WorkerDatabase")
     @patch("src.videos.veo_service.GenAIModelSetup.get_omni_client")
@@ -1453,6 +1458,11 @@ class TestBackgroundWorkers:
 
             mock_media_repo.update.assert_called_once()
             mock_vertex_client.interactions.create.assert_called_once()
+            call_kwargs = mock_vertex_client.interactions.create.call_args[1]
+            assert call_kwargs["response_format"] == {
+                "type": "video",
+                "duration": "8s",
+            }
 
     @patch("src.database.WorkerDatabase")
     @patch("src.videos.veo_service.GenAIModelSetup.get_omni_client")
@@ -1698,6 +1708,10 @@ class TestBackgroundWorkers:
                 for item in input_list
                 if item.get("type") == "text"
             )
+            assert call_kwargs["response_format"] == {
+                "type": "video",
+                "duration": "4s",
+            }
             update_dict = mock_media_repo.update.call_args[0][1]
             assert update_dict["status"] == JobStatusEnum.COMPLETED
             assert update_dict["gcs_uris"] == [

--- a/frontend/src/app/common/components/flow-prompt-box/flow-prompt-box.component.spec.ts
+++ b/frontend/src/app/common/components/flow-prompt-box/flow-prompt-box.component.spec.ts
@@ -128,6 +128,41 @@ describe('FlowPromptBoxComponent', () => {
       closeBtn.triggerEventHandler('click', {stopPropagation: () => {}});
       expect(component.clearExternalUrl.emit).toHaveBeenCalled();
     });
+
+    it('should disable Nano Banana 2 Lite and enable Nano Banana 2 in Video to Image mode', () => {
+      component.generationModels = MODEL_CONFIGS;
+      component.isSettingsMenuOpen.set(true);
+      component.isSettingsDropdownOpen.set('model');
+      fixture.detectChanges();
+
+      const modelButtons = fixture.debugElement.queryAll(
+        By.css('div.max-h-80 button'),
+      );
+      const nanoBanana2Btn = modelButtons.find(
+        btn =>
+          btn.nativeElement.textContent.trim().startsWith('Nano Banana 2') &&
+          !btn.nativeElement.textContent.includes('Lite') &&
+          !btn.nativeElement.textContent.includes('Pro'),
+      );
+      const nanoBanana2LiteBtn = modelButtons.find(btn =>
+        btn.nativeElement.textContent.includes('Nano Banana 2 Lite'),
+      );
+
+      expect(nanoBanana2Btn?.nativeElement.disabled).toBeFalse();
+      expect(nanoBanana2LiteBtn?.nativeElement.disabled).toBeTrue();
+    });
+
+    it('should not allow selecting Nano Banana 2 Lite in Video to Image mode', () => {
+      component.generationModels = MODEL_CONFIGS;
+      const nanoBanana2Lite = MODEL_CONFIGS.find(
+        m => m.value === 'gemini-3.1-flash-lite-image',
+      )!;
+      spyOn(component.modelSelected, 'emit');
+
+      component.selectInternalModel(nanoBanana2Lite);
+
+      expect(component.modelSelected.emit).not.toHaveBeenCalled();
+    });
   });
 
   describe('Edit Overlay Visibility', () => {

--- a/frontend/src/app/common/components/flow-prompt-box/flow-prompt-box.component.spec.ts
+++ b/frontend/src/app/common/components/flow-prompt-box/flow-prompt-box.component.spec.ts
@@ -283,4 +283,41 @@ describe('FlowPromptBoxComponent', () => {
       expect(component.isSettingsDropdownOpen()).toBeNull();
     });
   });
+
+  describe('Duration Support', () => {
+    const geminiOmni = MODEL_CONFIGS.find(
+      m => m.value === 'gemini-omni-flash-preview',
+    )!;
+
+    beforeEach(() => {
+      component.generationModels = MODEL_CONFIGS;
+    });
+
+    it('should support [4, 6, 8, 10] durations for Gemini Omni Flash in Text to Video mode', () => {
+      component.selectedGenerationModel = geminiOmni.viewValue;
+      component.mode = 'Text to Video';
+
+      const durations = component.getSelectedModelDurations();
+      expect(durations).toEqual([4, 6, 8, 10]);
+      expect(component.hasDurationOptions()).toBeTrue();
+    });
+
+    it('should return only the longest duration (10s) for Gemini Omni Flash in Ingredients to Video mode', () => {
+      component.selectedGenerationModel = geminiOmni.viewValue;
+      component.mode = 'Ingredients to Video';
+
+      const durations = component.getSelectedModelDurations();
+      expect(durations).toEqual([10]);
+    });
+
+    it('should update selectedDuration and emit durationChanged on selectDuration', () => {
+      component.selectedGenerationModel = geminiOmni.viewValue;
+      component.mode = 'Text to Video';
+      spyOn(component.durationChanged, 'emit');
+
+      component.selectDuration(10);
+      expect(component.selectedDuration()).toBe(10);
+      expect(component.durationChanged.emit).toHaveBeenCalledWith(10);
+    });
+  });
 });

--- a/frontend/src/app/common/config/model-config.ts
+++ b/frontend/src/app/common/config/model-config.ts
@@ -112,7 +112,6 @@ export const MODEL_CONFIGS: GenerationModelConfig[] = [
       supportedResolutions: ['1K'],
       supportedDurations: [],
       supportsGoogleSearch: true,
-      supportsVideoReference: true,
     },
   },
   {

--- a/frontend/src/app/common/config/model-config.ts
+++ b/frontend/src/app/common/config/model-config.ts
@@ -239,7 +239,7 @@ export const MODEL_CONFIGS: GenerationModelConfig[] = [
       maxReferenceImages: 3,
       supportedAspectRatios: ['16:9', '9:16'],
       supportedResolutions: [],
-      supportedDurations: [4, 6, 8],
+      supportedDurations: [4, 6, 8, 10],
       supportsAudio: true,
     },
   },

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -280,6 +280,20 @@ describe('HomeComponent', () => {
       expect(component.searchRequest.aspectRatio).not.toBe('auto');
       expect(component.searchRequest.aspectRatio).toBe('1:1');
     });
+
+    it('should fallback to a compatible model (Nano Banana 2) when switching to Video to Image mode from Nano Banana 2 Lite', () => {
+      const nanoBanana2Lite = component.generationModels.find(
+        m => m.value === 'gemini-3.1-flash-lite-image',
+      )!;
+      component.selectModel(nanoBanana2Lite);
+      expect(component.selectedGenerationModel).toBe('Nano Banana 2 Lite');
+
+      component.onModeChanged('Video to Image');
+      expect(component.selectedGenerationModel).toBe('Nano Banana 2');
+      expect(component.selectedGenerationModelObject?.value).toBe(
+        'gemini-3.1-flash-image',
+      );
+    });
   });
 
   it('should toggle style and save state when selecting an image style', () => {


### PR DESCRIPTION
Fixes #N/A

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

# Fixes

| Description | Before | After |
| ------- | ------- | ------- |
| Nano Banana 2 Lite should be disabled for Video to image | <img width="512" height="307" alt="image" src="https://github.com/user-attachments/assets/21923879-ed74-441a-815e-c5c430bdb166" /> | <img width="512" height="307" alt="image" src="https://github.com/user-attachments/assets/0e51e9f3-edca-4a12-9518-39fa852f92a3" /> |
|  Expect to allow 10 sec for Omni video generation | <img width="712" height="427" alt="image" src="https://github.com/user-attachments/assets/404c55ed-28b8-4601-b634-1beb39650384" /> |  <img width="512" height="307" alt="image" src="https://github.com/user-attachments/assets/2f4dd8db-35a3-4531-9e0b-66e2f12f804c" /> |
| Video generated with Gemini Omni Flash always video duration is 10 sec | Duration set as 4 sec generated video of 10 sec of duration | Duration set as 4 sec generated video of 4 sec of duration |