### PR TITLE
feat(creative-studio): deployed Creative Studio to a dedicated project on GCP

### DIFF
--- a/.supervision/creative-studio-private-sql/concept.md
+++ b/.supervision/creative-studio-private-sql/concept.md
@@ -1,0 +1,30 @@
+# Concept: Creative Studio Private SQL
+
+## Intent
+
+Deploy the internal Creative Studio trial in `iconic-ds-creative-studio-dev` in `us-central1` without a public Cloud SQL address. Preserve the existing Cloud Run Cloud SQL Auth Proxy socket integration while making the proxy reach the instance over private networking.
+
+## Constraints
+
+- The deployment must use `feature/KN-DATAX-15064-deploy-creative-studio` in the organisation-owned fork.
+- The inherited `constraints/sql.restrictPublicIp` policy prohibits public Cloud SQL IP addresses.
+- Do not apply or destroy infrastructure until Terraform plan review confirms the private design.
+- Do not store credentials, Terraform state, generated environment directories, bootstrap state, or tfvars containing real values in Git.
+- Keep project resources and the VPC connector in `us-central1`; use no shared development project resources.
+- The existing administrative Shared VPC arrangement may require network-user or service-agent permissions in the host project. Terraform must accept an approved existing network rather than assume it can create a new one there.
+
+## Design
+
+- Create a reusable Terraform networking module that either creates a dedicated VPC or consumes an explicitly supplied approved VPC network.
+- Reserve a global internal range and create Private Services Access peering for `servicenetworking.googleapis.com`.
+- Configure Cloud SQL PostgreSQL with `ipv4_enabled = false` and the selected VPC network. The instance receives only a private address.
+- Create a regional Serverless VPC Access connector with a non-overlapping `/28` CIDR range in `us-central1`.
+- Attach only the backend Cloud Run service to that connector with `PRIVATE_RANGES_ONLY` egress. The backend's Cloud SQL Python Connector is explicitly configured for `PRIVATE` IP; this corrects the former implicit `PUBLIC` connector path.
+- Enable the Compute Engine, Service Networking, and Serverless VPC Access APIs. Retain existing Cloud SQL client and Secret Manager IAM bindings.
+- Expose non-sensitive outputs needed to validate the connection and document manual host-project permissions where a Shared VPC is selected.
+
+## Trade-offs
+
+- A Serverless VPC Access connector has ongoing cost and throughput/scale limits, but is supported by established Cloud Run Terraform fields and avoids requiring a newer provider for Direct VPC egress.
+- A dedicated VPC is self-contained for a time-boxed trial, while an existing Shared VPC can meet organisational networking requirements but needs host-project coordination and preallocated non-overlapping ranges.
+- `PRIVATE_RANGES_ONLY` routes database traffic privately without forcing all Internet-bound backend traffic through a NAT gateway. This is the smallest change compatible with the Cloud SQL Python Connector path.

--- a/.supervision/creative-studio-private-sql/progress.md
+++ b/.supervision/creative-studio-private-sql/progress.md
@@ -18,6 +18,7 @@
 
 ### 2026-08-20 Private Cloud SQL Deployment
 
+- Validated fresh Cloud Shell checkout — **Finding**: Terraform initialized the private-networking module, then Google provider v7.45.0 rejected `project` on `google_service_networking_connection` — **Decision**: remove the unsupported attribute; the fully qualified VPC self link identifies the network-owning project.
 - Resumed deployment investigation — **Finding**: Cloud SQL apply attempted a public IP despite the feature branch setting `ipv4_enabled = false`; bootstrap reuses an existing checkout without previously switching it to the branch entered by the user — **Decision**: update a clean existing checkout to the selected branch before reuse and document the recovery commands.
 - Committed implementation — **Finding**: static diagnostics and Git whitespace checks pass, while `uv`, `terraform`, and `gcloud` are unavailable locally — **Decision**: commit the reviewed change without apply; require Cloud Shell Terraform formatting, validation, plan review, and runtime validation before deployment.
 - Implemented private connectivity — **Finding**: the application selected `IPTypes.PUBLIC` when `USE_CLOUD_SQL_AUTH_PROXY` was unset, despite mounting the Cloud SQL socket — **Decision**: configure the Python Connector with an explicit validated IP type and set `CLOUD_SQL_IP_TYPE=PRIVATE` in the deployment.

--- a/.supervision/creative-studio-private-sql/progress.md
+++ b/.supervision/creative-studio-private-sql/progress.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **State**: Executing
-- **Current Objective**: Correct bootstrap branch reuse before resuming the private Cloud SQL deployment.
+- **Current Objective**: Correct Alembic private-IP selection and complete private-network seeding.
 
 ## Plan
 
@@ -13,11 +13,13 @@
 - [x] Phase 4: Add deployment, validation, and teardown documentation.
 - [x] Phase 5: Run available validation and commit.
 - [ ] Phase 6: Validate and commit bootstrap branch-resume correction.
+- [ ] Phase 7: Validate and commit Alembic private-IP migration correction.
 
 ## Journal
 
 ### 2026-08-20 Private Cloud SQL Deployment
 
+- Validated deployed backend — **Finding**: Cloud SQL is `RUNNABLE` with only private IP `172.30.0.3`, but Alembic's connector was hard-coded to `IPTypes.PUBLIC`, producing `CloudSQLIPTypeError` with preference `PRIMARY` — **Decision**: make Alembic honor `CLOUD_SQL_IP_TYPE`; Cloud Shell remains unsuitable for private-only seeding, so use a VPC-attached Cloud Run Job after the corrected image deploys.
 - Validated fresh Cloud Shell checkout — **Finding**: Terraform initialized the private-networking module, then Google provider v7.45.0 rejected `project` on `google_service_networking_connection` — **Decision**: remove the unsupported attribute; the fully qualified VPC self link identifies the network-owning project.
 - Resumed deployment investigation — **Finding**: Cloud SQL apply attempted a public IP despite the feature branch setting `ipv4_enabled = false`; bootstrap reuses an existing checkout without previously switching it to the branch entered by the user — **Decision**: update a clean existing checkout to the selected branch before reuse and document the recovery commands.
 - Committed implementation — **Finding**: static diagnostics and Git whitespace checks pass, while `uv`, `terraform`, and `gcloud` are unavailable locally — **Decision**: commit the reviewed change without apply; require Cloud Shell Terraform formatting, validation, plan review, and runtime validation before deployment.

--- a/.supervision/creative-studio-private-sql/progress.md
+++ b/.supervision/creative-studio-private-sql/progress.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **State**: Completed
-- **Current Objective**: Private Cloud SQL connectivity is implemented and committed; deployment remains unapplied pending plan review.
+- **State**: Executing
+- **Current Objective**: Correct bootstrap branch reuse before resuming the private Cloud SQL deployment.
 
 ## Plan
 
@@ -12,11 +12,13 @@
 - [x] Phase 3: Implement Terraform networking and Cloud Run connectivity.
 - [x] Phase 4: Add deployment, validation, and teardown documentation.
 - [x] Phase 5: Run available validation and commit.
+- [ ] Phase 6: Validate and commit bootstrap branch-resume correction.
 
 ## Journal
 
 ### 2026-08-20 Private Cloud SQL Deployment
 
+- Resumed deployment investigation — **Finding**: Cloud SQL apply attempted a public IP despite the feature branch setting `ipv4_enabled = false`; bootstrap reuses an existing checkout without previously switching it to the branch entered by the user — **Decision**: update a clean existing checkout to the selected branch before reuse and document the recovery commands.
 - Committed implementation — **Finding**: static diagnostics and Git whitespace checks pass, while `uv`, `terraform`, and `gcloud` are unavailable locally — **Decision**: commit the reviewed change without apply; require Cloud Shell Terraform formatting, validation, plan review, and runtime validation before deployment.
 - Implemented private connectivity — **Finding**: the application selected `IPTypes.PUBLIC` when `USE_CLOUD_SQL_AUTH_PROXY` was unset, despite mounting the Cloud SQL socket — **Decision**: configure the Python Connector with an explicit validated IP type and set `CLOUD_SQL_IP_TYPE=PRIVATE` in the deployment.
 - Added VPC resources — **Finding**: the provider configuration has no version constraints or lock file — **Decision**: use the broadly supported Serverless VPC Access connector rather than Direct VPC egress; use `PRIVATE_RANGES_ONLY` to avoid requiring Cloud NAT for Internet traffic.

--- a/.supervision/creative-studio-private-sql/progress.md
+++ b/.supervision/creative-studio-private-sql/progress.md
@@ -1,0 +1,26 @@
+# Progress
+
+## Status
+
+- **State**: Completed
+- **Current Objective**: Private Cloud SQL connectivity is implemented and committed; deployment remains unapplied pending plan review.
+
+## Plan
+
+- [x] Phase 1: Check branch, repository state, deployment wiring, and provider constraints.
+- [x] Phase 2: Establish the private Cloud SQL concept and risks.
+- [x] Phase 3: Implement Terraform networking and Cloud Run connectivity.
+- [x] Phase 4: Add deployment, validation, and teardown documentation.
+- [x] Phase 5: Run available validation and commit.
+
+## Journal
+
+### 2026-08-20 Private Cloud SQL Deployment
+
+- Committed implementation — **Finding**: static diagnostics and Git whitespace checks pass, while `uv`, `terraform`, and `gcloud` are unavailable locally — **Decision**: commit the reviewed change without apply; require Cloud Shell Terraform formatting, validation, plan review, and runtime validation before deployment.
+- Implemented private connectivity — **Finding**: the application selected `IPTypes.PUBLIC` when `USE_CLOUD_SQL_AUTH_PROXY` was unset, despite mounting the Cloud SQL socket — **Decision**: configure the Python Connector with an explicit validated IP type and set `CLOUD_SQL_IP_TYPE=PRIVATE` in the deployment.
+- Added VPC resources — **Finding**: the provider configuration has no version constraints or lock file — **Decision**: use the broadly supported Serverless VPC Access connector rather than Direct VPC egress; use `PRIVATE_RANGES_ONLY` to avoid requiring Cloud NAT for Internet traffic.
+- Validation environment — **Finding**: neither `uv` nor `terraform` is installed in the local execution environment — **Decision**: record focused test and Terraform validation as pending Cloud Shell or a configured developer environment.
+- Inspected the organisation fork on `feature/KN-DATAX-15064-deploy-creative-studio` — **Finding**: existing untracked `AGENTS.md` and `README_monorepo.md` are user files and will remain untouched — **Decision**: make implementation changes only in tracked Creative Studio deployment files.
+- Traced the database path — **Finding**: the backend Cloud Run service mounts the Cloud SQL Auth Proxy socket at `/cloudsql/<instance-connection-name>` but has no VPC connectivity; PostgreSQL enables public IPv4 — **Decision**: retain the socket path and add private VPC connectivity for the backend only.
+- Reviewed provider declarations — **Finding**: the example environment does not constrain Google provider versions — **Decision**: use Serverless VPC Access connector fields rather than require Direct VPC egress support from an unknown provider version.

--- a/.supervision/trial-warning-banner/concept.md
+++ b/.supervision/trial-warning-banner/concept.md
@@ -1,0 +1,26 @@
+# Concept: Trial Warning Banner
+
+## Intent
+
+Warn Creative Studio trial users not to enter, upload, or generate sensitive, confidential, or personal information.
+
+## Constraints
+
+- Implement on branch `KN-DATAX-15227-Put-a-warning-banner-onto-Creative-Studio-Frontend-for-trial`.
+- Show the warning across authenticated Creative Studio and admin routes.
+- Exclude login, password-reset, and support-ticket routes, which do not render the standard application shell.
+- Keep navigation and primary content usable on desktop and mobile viewports.
+- Use the existing Angular and Tailwind styling conventions; do not add dependencies.
+- Do not modify existing untracked deployment handoff, log, or reference files.
+
+## Design
+
+- Add a persistent red warning banner in the root Angular application shell, above `app-header`.
+- Use the copy: `Trial environment: Do not enter, upload, or generate sensitive, confidential, or personal information.`
+- Reuse `AppComponent` route state so the banner renders only when the authenticated application shell is shown.
+- Add focused styles in `AppComponent` and a focused test asserting the banner and warning copy render.
+
+## Trade-offs
+
+- A root-shell banner gives all authenticated routes one consistent warning with minimal maintenance, but it remains visible while users work and consumes a small amount of vertical space.
+- Excluding authentication and support flows limits warning coverage before sign-in, but preserves the existing simplified layouts and focuses the notice where users provide application content.

--- a/.supervision/trial-warning-banner/progress.md
+++ b/.supervision/trial-warning-banner/progress.md
@@ -1,0 +1,23 @@
+# Progress
+
+## Status
+
+- **State**: Executing
+- **Current Objective**: Resolve local frontend dependency installation, then run focused banner validation.
+
+## Plan
+
+- [x] Phase 1: Confirm branch, repository guidance, and the root application shell.
+- [x] Phase 2: Establish intent, constraints, design, and trade-offs.
+- [x] Phase 3: Add the authenticated-route warning banner and focused styling.
+- [ ] Phase 4: Add focused test coverage and run frontend validation.
+- [ ] Phase 5: Update status and prepare the pull request summary.
+
+## Journal
+
+### 2026-08-24 Trial Warning Banner
+
+- Implemented root-shell warning — **Finding**: `showHeader` controls the authenticated application shell — **Decision**: render an accessible red alert above `app-header`, with a focused spec that verifies the alert is shown only when that shell is visible.
+- Attempted focused validation — **Finding**: `npm test -- --include='src/app/app.component.spec.ts' --watch=false` did not run because `tsc` is absent; `npm ci` then failed to validate the package registry certificate under Node `v24.19.0`, which also produces an unsupported-engine warning — **Decision**: make no source changes until dependencies can be installed with the organisation's trusted certificate configuration and a supported Node version.
+- Reviewed the root Angular shell and route visibility logic — **Finding**: `AppComponent` already decides whether the standard header is shown, covering authenticated application and admin routes while excluding login-related routes — **Decision**: render the warning alongside the existing standard shell above `app-header`.
+- Reviewed repository workflow — **Finding**: this is a non-trivial user-facing frontend change on a non-main feature branch — **Decision**: create this task-specific supervision record before implementation.

--- a/.supervision/trial-warning-banner/progress.md
+++ b/.supervision/trial-warning-banner/progress.md
@@ -17,6 +17,7 @@
 
 ### 2026-08-24 Trial Warning Banner
 
+- Validated the pushed banner commit in Cloud Shell — **Finding**: TypeScript compilation passed, the focused Karma test remains blocked because Cloud Shell has no ChromeHeadless binary, and lint reported four Prettier errors only in the new warning assertion — **Decision**: reformat the assertion locally, then push a follow-up commit and rerun lint in Cloud Shell; the remaining 335 lint warnings predate this change.
 - Implemented root-shell warning — **Finding**: `showHeader` controls the authenticated application shell — **Decision**: render an accessible red alert above `app-header`, with a focused spec that verifies the alert is shown only when that shell is visible.
 - Attempted focused validation — **Finding**: `npm test -- --include='src/app/app.component.spec.ts' --watch=false` did not run because `tsc` is absent; `npm ci` then failed to validate the package registry certificate under Node `v24.19.0`, which also produces an unsupported-engine warning — **Decision**: make no source changes until dependencies can be installed with the organisation's trusted certificate configuration and a supported Node version.
 - Reviewed the root Angular shell and route visibility logic — **Finding**: `AppComponent` already decides whether the standard header is shown, covering authenticated application and admin routes while excluding login-related routes — **Decision**: render the warning alongside the existing standard shell above `app-header`.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -115,7 +115,7 @@ async def alembic_get_connection():
         user=config_service.DB_USER,
         password=config_service.DB_PASS,
         db=config_service.DB_NAME,
-        ip_type=IPTypes.PUBLIC,
+        ip_type=IPTypes[config_service.CLOUD_SQL_IP_TYPE],
     )
     return conn
 

--- a/backend/src/config/config_service.py
+++ b/backend/src/config/config_service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Any, Literal
 
 import google.auth
 from google.auth.exceptions import DefaultCredentialsError
@@ -67,6 +67,7 @@ class ConfigService(BaseSettings):
     DB_PASS: str = "password"
     DB_NAME: str = "creative_studio"
     USE_CLOUD_SQL_AUTH_PROXY: bool = False
+    CLOUD_SQL_IP_TYPE: Literal["PUBLIC", "PRIVATE"] = "PUBLIC"
     DB_HOST: str = "localhost"
     DB_PORT: str = "5432"
 

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -131,7 +131,7 @@ async def get_connection():
         user=config_service.DB_USER,
         password=config_service.DB_PASS,
         db=config_service.DB_NAME,
-        ip_type=IPTypes.PUBLIC,  # Adjust if using Private IP
+        ip_type=IPTypes[config_service.CLOUD_SQL_IP_TYPE],
     )
 
     return conn
@@ -196,7 +196,7 @@ class WorkerDatabase:
                     user=config_service.DB_USER,
                     password=config_service.DB_PASS,
                     db=config_service.DB_NAME,
-                    ip_type=IPTypes.PUBLIC,
+                    ip_type=IPTypes[config_service.CLOUD_SQL_IP_TYPE],
                 )
 
             self.engine = create_async_engine(

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -17,6 +17,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from google.cloud.sql.connector import IPTypes
 
 from src.config.config_service import config_service
 from src.database import (
@@ -131,6 +132,7 @@ async def test_get_connection_cloud_sql():
             "INSTANCE_CONNECTION_NAME",
             "projects/p/locations/l/instances/i",
         ),
+        patch.object(config_service, "CLOUD_SQL_IP_TYPE", "PRIVATE"),
     ):
         mock_connector = AsyncMock()
         mock_connector.connect_async = AsyncMock(return_value="cloud_conn")
@@ -143,6 +145,14 @@ async def test_get_connection_cloud_sql():
 
             res = await get_connection()
             assert res == "cloud_conn"
+            mock_connector.connect_async.assert_awaited_once_with(
+                "projects/p/locations/l/instances/i",
+                "asyncpg",
+                user=config_service.DB_USER,
+                password=config_service.DB_PASS,
+                db=config_service.DB_NAME,
+                ip_type=IPTypes.PRIVATE,
+            )
 
 
 @pytest.mark.anyio

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -349,6 +349,23 @@ setup_repo() {
     if [[ -d "$REPO_CLONE_DIR" ]]; then
         warn "Directory '$REPO_CLONE_DIR' already exists."; prompt "Do you want to use this existing directory? (y/n)"; read -r REPLY < /dev/tty
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then fail "Please remove the directory or run the script from a different location."; fi
+
+        cd "$REPO_CLONE_DIR"
+        git rev-parse --is-inside-work-tree > /dev/null 2>&1 || fail "Existing directory '$REPO_CLONE_DIR' is not a Git repository."
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+            fail "Existing repository has uncommitted changes. Commit, stash, or use a new directory before continuing."
+        fi
+        if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+            fail "Existing repository has untracked files. Move them or use a new directory before continuing."
+        fi
+        info "Updating existing checkout to branch '$SELECTED_BRANCH'..."
+        git fetch origin "$SELECTED_BRANCH"
+        if git show-ref --verify --quiet "refs/heads/$SELECTED_BRANCH"; then
+            git checkout "$SELECTED_BRANCH"
+        else
+            git checkout --track "origin/$SELECTED_BRANCH"
+        fi
+        git pull --ff-only origin "$SELECTED_BRANCH"
     else
         info "Performing a sparse checkout of '$REPO_CLONE_DIR' (Branch: $SELECTED_BRANCH)..."
         
@@ -356,7 +373,7 @@ setup_repo() {
         git clone --filter=blob:none --no-checkout --depth 1 --sparse -b "$SELECTED_BRANCH" "$GITHUB_REPO_URL" "$REPO_CLONE_DIR"
         
         cd "$REPO_CLONE_DIR"
-        
+
         # 2. Sparse checkout for ROOT folders only
         git sparse-checkout set "infra" "backend" "frontend" "bootstrap.sh"
         

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -366,6 +366,7 @@ setup_repo() {
             git checkout --track "origin/$SELECTED_BRANCH"
         fi
         git pull --ff-only origin "$SELECTED_BRANCH"
+        cd ..
     else
         info "Performing a sparse checkout of '$REPO_CLONE_DIR' (Branch: $SELECTED_BRANCH)..."
         

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -20,6 +20,10 @@
   mode="indeterminate"
 ></mat-progress-bar>
 <app-notification-container></app-notification-container>
+<div *ngIf="showHeader" class="trial-warning" role="alert">
+  Trial environment: Do not enter, upload, or generate sensitive,
+  confidential, or personal information.
+</div>
 <app-header *ngIf="showHeader"></app-header>
 <div
   [ngClass]="showHeader ? 'content' : 'login'"

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -25,6 +25,18 @@
   position: relative;
 }
 
+.trial-warning {
+  background-color: #b91c1c;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+  padding: 0.5rem 1rem;
+  position: relative;
+  text-align: center;
+  z-index: 40;
+}
+
 ::ng-deep .mat-mdc-snack-bar-container {
   &.green-snackbar {
     --mdc-snackbar-container-color: #0f9d58;

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -55,10 +55,11 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
 
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('.trial-warning')?.textContent)
-      .toContain(
-        'Do not enter, upload, or generate sensitive, confidential, or personal information.',
-      );
+    expect(
+      fixture.nativeElement.querySelector('.trial-warning')?.textContent,
+    ).toContain(
+      'Do not enter, upload, or generate sensitive, confidential, or personal information.',
+    );
 
     app.showHeader = false;
     fixture.detectChanges();

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -16,6 +16,7 @@
 
 import {TestBed} from '@angular/core/testing';
 import {RouterTestingModule} from '@angular/router/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {AppComponent} from './app.component';
 import {LoadingService} from './common/services/loading.service';
 import {of} from 'rxjs';
@@ -30,7 +31,7 @@ describe('AppComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, NoopAnimationsModule],
       declarations: [AppComponent],
       providers: [{provide: LoadingService, useValue: loadingServiceMock}],
       schemas: [NO_ERRORS_SCHEMA],
@@ -47,5 +48,20 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app.title).toEqual('creative-studio');
+  });
+
+  it('should show the trial warning only with the application header', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.trial-warning')?.textContent)
+      .toContain(
+        'Do not enter, upload, or generate sensitive, confidential, or personal information.',
+      );
+
+    app.showHeader = false;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.trial-warning')).toBeNull();
   });
 });

--- a/infra/PRIVATE_SQL_DEPLOYMENT.md
+++ b/infra/PRIVATE_SQL_DEPLOYMENT.md
@@ -1,0 +1,140 @@
+# Private Cloud SQL Deployment
+
+## Purpose
+
+This runbook deploys the internal Creative Studio trial to
+`iconic-ds-creative-studio-dev` in `us-central1`. It replaces the upstream
+public Cloud SQL address with private IP because the inherited organisation
+policy `constraints/sql.restrictPublicIp` rejects public database addresses.
+
+The deployment creates a Cloud SQL private IP, a VPC, a Private Services
+Access allocation and peering, and a Serverless VPC Access connector. The
+backend Cloud Run revision uses `PRIVATE_RANGES_ONLY` egress through that
+connector. Its Cloud SQL Python Connector is configured with
+`CLOUD_SQL_IP_TYPE=PRIVATE`. The frontend never receives VPC access.
+
+## Prerequisites
+
+- Use only project `iconic-ds-creative-studio-dev` and region `us-central1`.
+- Use the organisation fork `https://github.com/theiconic/gcc-creative-studio`.
+- Create the Cloud Build connection `gh-creative-studio-deploy-con` in
+  `us-central1` and grant its GitHub App access to `theiconic/gcc-creative-studio`.
+- Enable or allow Terraform to enable `compute.googleapis.com`,
+  `servicenetworking.googleapis.com`, `vpcaccess.googleapis.com`,
+  `sqladmin.googleapis.com`, `run.googleapis.com`, and the APIs listed in
+  `dev.tfvars`.
+- The Terraform identity needs Cloud SQL, Cloud Run, Cloud Build, Secret
+  Manager, Service Usage, Service Networking, Compute Network Admin, and
+  Serverless VPC Access administration permissions in the owning projects.
+- The backend runtime service account needs `roles/cloudsql.client`; Terraform
+  creates this binding.
+
+### Shared VPC
+
+The default configuration creates a dedicated VPC in the deployment project.
+For an organisation-approved Shared VPC, set `network_project_id` and the full
+`network_self_link` in the generated, uncommitted environment tfvars file.
+Choose an unused Private Services Access range and unused connector `/28` with
+the network owner. The Terraform identity and relevant Google service agents
+must have the host-project permissions to create the private-services range,
+peering, and connector attachment. Do not apply until the network owner has
+confirmed those values and permissions.
+
+If the selected Shared VPC already has a Service Networking connection for
+`servicenetworking.googleapis.com`, import it into Terraform state before the
+apply rather than creating a duplicate connection. Do not commit that state.
+
+## Bootstrap Or Resume
+
+1. Push the reviewed feature branch to the organisation fork before using
+   Cloud Shell. The bootstrap script must come from the same branch as the
+   Terraform change:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/theiconic/gcc-creative-studio/feature/KN-DATAX-15064-deploy-creative-studio/bootstrap.sh | bash
+   ```
+
+2. Enter `https://github.com/theiconic/gcc-creative-studio.git` when prompted
+   for the fork URL. Enter
+   `feature/KN-DATAX-15064-deploy-creative-studio` when prompted for the Git
+   branch. Enter `gh-creative-studio-deploy-con` for the Cloud Build connection.
+3. Use `iconic-ds-creative-studio-dev`; keep `us-central1` unchanged.
+4. In the generated `infra/environments/dev-infra/dev-infra.tfvars`, set the
+   approved Shared VPC values if applicable. Never commit this directory,
+   `.bootstrap_state`, Terraform state, or secrets.
+5. Run `terraform init -reconfigure`, `terraform fmt -check -recursive`, and
+   `terraform validate` in that environment. Review `terraform plan` before
+   answering yes to bootstrap's apply prompt.
+
+The Cloud Build repository resource must reference owner `theiconic`, repository
+`gcc-creative-studio`, and the healthy `us-central1` connection. If Terraform
+reports that a manually linked repository already exists, import that resource
+into the generated environment state before retrying; do not create another
+connection or switch to a personal fork.
+
+## Validation
+
+Before applying, a reviewed plan must show:
+
+- `google_sql_database_instance` with `ipv4_enabled = false` and a
+  `private_network`.
+- a `google_compute_global_address` for `VPC_PEERING` and a
+  `google_service_networking_connection`.
+- a `google_vpc_access_connector` in `us-central1`.
+- backend Cloud Run `vpc_access` with `PRIVATE_RANGES_ONLY`.
+- no public Cloud SQL address or `IPTypes.PUBLIC` deployment setting.
+
+After an approved apply, run:
+
+```bash
+gcloud sql instances describe INSTANCE_NAME \
+  --project=iconic-ds-creative-studio-dev \
+  --format='yaml(ipAddresses,region,state)'
+
+gcloud run services describe cstudio-be \
+  --region=us-central1 \
+  --project=iconic-ds-creative-studio-dev \
+  --format='yaml(spec.template.spec.containers,spec.template.metadata.annotations)'
+
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="cstudio-be"' \
+  --project=iconic-ds-creative-studio-dev \
+  --limit=100
+```
+
+Confirm the SQL instance has only a `PRIVATE` address, the backend revision is
+ready, and startup/request logs contain no database connection errors. Then use
+the Firebase Hosting URL from `terraform output frontend_service_url`, sign in
+as a member of `tech.data.datascience@theiconic.com.au`, and perform a workflow
+that reads and writes application data. Expected endpoints are the Firebase
+Hosting URL and the backend Cloud Run URL from `terraform output`; the database
+has no public endpoint.
+
+## Limits And Cost
+
+- A Serverless VPC Access connector incurs ongoing hourly and data-processing
+  cost while it exists. Cloud SQL, Cloud Run minimum instances, storage,
+  Artifact Registry, Cloud Build, Firebase, and generated media storage also
+  incur trial costs.
+- `PRIVATE_RANGES_ONLY` does not provide general Internet egress through the
+  VPC. If the backend later requires controlled VPC Internet egress, add Cloud
+  NAT and review the architecture rather than changing egress ad hoc.
+- This configuration is for the internal time-boxed trial only. It does not
+  add production HA, backup, monitoring, retention, or long-term support.
+
+## Teardown
+
+1. Preserve any data or logs required by the trial owner, then disable Cloud
+   Build triggers to prevent a rebuild during teardown.
+2. From the generated environment directory, run and review `terraform plan
+   -destroy`, then run `terraform destroy` only after approval.
+3. Verify Cloud Run services, Cloud SQL, the connector, Private Services
+   Access peering/allocation, buckets, Cloud Build triggers/repositories,
+   secrets, Firebase resources, and generated service accounts are gone or
+   intentionally retained.
+4. Remove manually created Firebase apps, OAuth clients, the Cloud Build
+   connection, and the Terraform state bucket only when no other workload uses
+   them. Deleting the state bucket is irreversible and must happen last.
+5. For Shared VPC, have the host-project network owner confirm that the private
+   services allocation and peering are safe to remove; they may be shared with
+   other workloads. Remove only resources created specifically for this trial.

--- a/infra/PRIVATE_SQL_DEPLOYMENT.md
+++ b/infra/PRIVATE_SQL_DEPLOYMENT.md
@@ -66,6 +66,31 @@ apply rather than creating a duplicate connection. Do not commit that state.
    `terraform validate` in that environment. Review `terraform plan` before
    answering yes to bootstrap's apply prompt.
 
+When resuming a prior bootstrap run, first confirm the existing checkout uses
+the feature branch. The bootstrap script updates a clean existing checkout to
+the selected branch. For an older checkout created before this behavior was
+available, run the following from its parent directory before resuming:
+
+```bash
+cd gcc-creative-studio
+git status --short
+git fetch origin feature/KN-DATAX-15064-deploy-creative-studio
+git switch feature/KN-DATAX-15064-deploy-creative-studio
+git pull --ff-only origin feature/KN-DATAX-15064-deploy-creative-studio
+gcloud services enable servicenetworking.googleapis.com vpcaccess.googleapis.com \
+  --project=iconic-ds-creative-studio-dev
+```
+
+Do not discard or overwrite `infra/environments/dev-infra/`; it contains the
+uncommitted generated Terraform configuration and resume state. Verify the
+module source after the branch update before running another plan:
+
+```bash
+grep -A3 'ip_configuration' infra/modules/postgresql/main.tf
+```
+
+It must show `ipv4_enabled = false` and `private_network = var.private_network`.
+
 The Cloud Build repository resource must reference owner `theiconic`, repository
 `gcc-creative-studio`, and the healthy `us-central1` connection. If Terraform
 reports that a manually linked repository already exists, import that resource

--- a/infra/PRIVATE_SQL_DEPLOYMENT.md
+++ b/infra/PRIVATE_SQL_DEPLOYMENT.md
@@ -17,7 +17,7 @@ connector. Its Cloud SQL Python Connector is configured with
 
 - Use only project `iconic-ds-creative-studio-dev` and region `us-central1`.
 - Use the organisation fork `https://github.com/theiconic/gcc-creative-studio`.
-- Create the Cloud Build connection `gh-creative-studio-deploy-con` in
+- Create the Cloud Build connection `gh-creative-studio-deploy-con-ti` in
   `us-central1` and grant its GitHub App access to `theiconic/gcc-creative-studio`.
 - Enable or allow Terraform to enable `compute.googleapis.com`,
   `servicenetworking.googleapis.com`, `vpcaccess.googleapis.com`,
@@ -57,7 +57,7 @@ apply rather than creating a duplicate connection. Do not commit that state.
 2. Enter `https://github.com/theiconic/gcc-creative-studio.git` when prompted
    for the fork URL. Enter
    `feature/KN-DATAX-15064-deploy-creative-studio` when prompted for the Git
-   branch. Enter `gh-creative-studio-deploy-con` for the Cloud Build connection.
+  branch. Enter `gh-creative-studio-deploy-con-ti` for the Cloud Build connection.
 3. Use `iconic-ds-creative-studio-dev`; keep `us-central1` unchanged.
 4. In the generated `infra/environments/dev-infra/dev-infra.tfvars`, set the
    approved Shared VPC values if applicable. Never commit this directory,
@@ -134,6 +134,24 @@ as a member of `tech.data.datascience@theiconic.com.au`, and perform a workflow
 that reads and writes application data. Expected endpoints are the Firebase
 Hosting URL and the backend Cloud Run URL from `terraform output`; the database
 has no public endpoint.
+
+### Migrations and initial data
+
+The Cloud SQL Python Connector must use `CLOUD_SQL_IP_TYPE=PRIVATE` for both
+application connections and Alembic migrations. A Cloud Run revision that logs
+`CloudSQLIPTypeError` with preference `PRIMARY` is running code that predates
+the private-IP migration fix; rebuild it from the feature branch before
+continuing.
+
+Cloud Shell is not attached to the dedicated VPC, so the bootstrap script's
+local Cloud SQL Auth Proxy cannot seed this private-only database. Do not add a
+public SQL IP as a workaround. After the backend image is deployed successfully
+and migrations complete, use a one-time Cloud Run Job attached to
+`cs-development-vpc` with `private-ranges-only` egress to run
+`python -m bootstrap.bootstrap`. Configure the job with the backend runtime
+service account, the same `INSTANCE_CONNECTION_NAME`, `CLOUD_SQL_IP_TYPE=PRIVATE`,
+database settings, bucket name, admin email, and `DB_PASS` secret used by the
+backend service. Review and retain the execution logs as deployment evidence.
 
 ## Limits And Cost
 

--- a/infra/environments/dev-infra-example/dev.tfvars
+++ b/infra/environments/dev-infra-example/dev.tfvars
@@ -2,6 +2,14 @@ gcp_project_id = "YOUR_GCP_PROJECT_ID"
 gcp_region     = "us-central1"
 environment    = "development"
 
+# Use a dedicated VPC by default. For Shared VPC, set both values with the
+# approved host project and network self link, and use non-overlapping ranges.
+# network_project_id             = "YOUR_NETWORK_HOST_PROJECT_ID"
+# network_self_link              = "https://www.googleapis.com/compute/v1/projects/YOUR_NETWORK_HOST_PROJECT_ID/global/networks/YOUR_NETWORK_NAME"
+private_services_range_address = "172.30.0.0"
+private_services_range_prefix_length = 16
+vpc_connector_cidr            = "172.31.0.0/28"
+
 # --- Service Names ---
 backend_service_name  = "cstudio-backend-dev"
 frontend_service_name = "cstudio-frontend-dev" # This is the Cloud Run service name
@@ -71,4 +79,6 @@ apis_to_enable = [
   "firestore.googleapis.com",
   "texttospeech.googleapis.com",
   "workflows.googleapis.com",
+  "servicenetworking.googleapis.com",
+  "vpcaccess.googleapis.com",
 ]

--- a/infra/environments/dev-infra-example/main.tf
+++ b/infra/environments/dev-infra-example/main.tf
@@ -48,6 +48,11 @@ module "creative_studio_platform" {
   gcp_project_id            = var.gcp_project_id
   gcp_region                = var.gcp_region
   environment               = var.environment
+  network_project_id        = var.network_project_id
+  network_self_link         = var.network_self_link
+  private_services_range_address = var.private_services_range_address
+  private_services_range_prefix_length = var.private_services_range_prefix_length
+  vpc_connector_cidr        = var.vpc_connector_cidr
   backend_service_name      = var.backend_service_name
   backend_custom_audiences  = var.backend_custom_audiences
   be_env_vars               = var.be_env_vars

--- a/infra/environments/dev-infra-example/variables.tf
+++ b/infra/environments/dev-infra-example/variables.tf
@@ -28,6 +28,36 @@ variable "environment" {
   description = "The name of the environment, e.g., 'development'."
 }
 
+variable "network_project_id" {
+  type        = string
+  description = "Project that owns the VPC and Private Services Access resources. Defaults to gcp_project_id."
+  default     = ""
+}
+
+variable "network_self_link" {
+  type        = string
+  description = "Approved existing VPC self link. Leave empty to create a dedicated VPC."
+  default     = ""
+}
+
+variable "private_services_range_address" {
+  type        = string
+  description = "Unused RFC 1918 base address for Private Services Access."
+  default     = "172.30.0.0"
+}
+
+variable "private_services_range_prefix_length" {
+  type        = number
+  description = "Prefix length for the Private Services Access range."
+  default     = 16
+}
+
+variable "vpc_connector_cidr" {
+  type        = string
+  description = "Unused /28 CIDR for the backend Serverless VPC Access connector."
+  default     = "172.31.0.0/28"
+}
+
 # --- Service Names ---
 variable "backend_service_name" {
   type        = string
@@ -122,6 +152,8 @@ variable "apis_to_enable" {
     "iam.googleapis.com",              # Required for IAM management
     "cloudbuild.googleapis.com",       # Required for Cloud Build
     "artifactregistry.googleapis.com", # Required for Artifact Registry
-    "run.googleapis.com"               # Required for Cloud Run
+    "run.googleapis.com",              # Required for Cloud Run
+    "servicenetworking.googleapis.com", # Required for Private Services Access
+    "vpcaccess.googleapis.com"          # Required for Serverless VPC Access
   ]
 }

--- a/infra/modules/cloud-run-service/main.tf
+++ b/infra/modules/cloud-run-service/main.tf
@@ -39,11 +39,9 @@ resource "google_cloud_run_v2_service" "this" {
 
   template {
     service_account = google_service_account.run_sa.email
-    volumes {
-      name = "cloudsql"
-      cloud_sql_instance {
-        instances = [var.cloud_sql_connection_name]
-      }
+    vpc_access {
+      connector = var.vpc_connector_id
+      egress    = "PRIVATE_RANGES_ONLY"
     }
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello:latest"
@@ -57,10 +55,6 @@ resource "google_cloud_run_v2_service" "this" {
       env {
         name = "INSTANCE_CONNECTION_NAME"
         value = var.cloud_sql_connection_name
-      }
-      env {
-        name = "DB_HOST"
-        value = "/cloudsql/${var.cloud_sql_connection_name}"
       }
       env {
         name = "DB_NAME"
@@ -109,10 +103,6 @@ resource "google_cloud_run_v2_service" "this" {
         }
       }
 
-      volume_mounts {
-        name = "cloudsql"
-        mount_path = "/cloudsql"
-      }
     }
     scaling {
       min_instance_count = var.scaling_min_instances

--- a/infra/modules/cloud-run-service/variables.tf
+++ b/infra/modules/cloud-run-service/variables.tf
@@ -118,6 +118,11 @@ variable "runtime_secrets" {
   default     = {}
 }
 
+variable "vpc_connector_id" {
+  type        = string
+  description = "Serverless VPC Access connector used for private database traffic."
+}
+
 # database
 variable "cloud_sql_connection_name" {
   description = "Cloud SQL Instance Connection Name"

--- a/infra/modules/platform/main.tf
+++ b/infra/modules/platform/main.tf
@@ -48,6 +48,10 @@ data "google_project" "project" {
   project_id = var.gcp_project_id
 }
 
+locals {
+  network_project_id = var.network_project_id != "" ? var.network_project_id : var.gcp_project_id
+}
+
 # --- Predictable URLs & Environment Variables ---
 locals {
   region_code  = join("", [for s in split("-", var.gcp_region) : substr(s, 0, 1)])
@@ -64,6 +68,7 @@ locals {
       "SIGNING_SA_EMAIL"       = google_service_account.bucket_reader_sa.email
       "BACKEND_URL"            = local.backend_url
       "WORKFLOWS_EXECUTOR_URL" = "${local.backend_url}/api/workflows-executor"
+      "CLOUD_SQL_IP_TYPE"      = "PRIVATE"
     }
   )
 }
@@ -86,14 +91,32 @@ data "google_secret_manager_secret_version" "db_password" {
   version = "latest"
 }
 
+module "private_networking" {
+  source = "../private-networking"
+
+  project_id                         = var.gcp_project_id
+  network_project_id                 = local.network_project_id
+  region                             = var.gcp_region
+  network_name                       = "cs-${var.environment}-private"
+  network_self_link                  = var.network_self_link
+  private_services_range_name        = "cs-${var.environment}-private-services"
+  private_services_range_address     = var.private_services_range_address
+  private_services_range_prefix_length = var.private_services_range_prefix_length
+  vpc_connector_name                 = "cs-${var.environment}-vpc"
+  vpc_connector_cidr                 = var.vpc_connector_cidr
+}
+
 # 2. Call PostgreSQL Module
 module "postgresql" {
   source      = "../postgresql"
   project_id  = var.gcp_project_id
   region      = var.gcp_region
+  private_network = module.private_networking.network_self_link
   
   # Pass the ACTUAL value to create the user
   db_password = data.google_secret_manager_secret_version.db_password.secret_data
+
+  depends_on = [module.private_networking]
 }
 
 # --- Service Module Calls ---
@@ -127,6 +150,7 @@ module "backend_service" {
 
   # database
   cloud_sql_connection_name = module.postgresql.connection_name
+  vpc_connector_id          = module.private_networking.vpc_connector_id
   db_name                   = module.postgresql.db_name
   db_user                   = module.postgresql.db_user
   

--- a/infra/modules/platform/variables.tf
+++ b/infra/modules/platform/variables.tf
@@ -16,6 +16,36 @@ variable "gcp_project_id" { type = string }
 variable "gcp_region" { type = string }
 variable "environment" { type = string }
 
+variable "network_project_id" {
+  type        = string
+  description = "Project that owns the VPC and Private Services Access resources. Defaults to the deployment project."
+  default     = ""
+}
+
+variable "network_self_link" {
+  type        = string
+  description = "Approved existing VPC self link. Leave empty to create a dedicated VPC."
+  default     = ""
+}
+
+variable "private_services_range_address" {
+  type        = string
+  description = "Unused RFC 1918 base address for Private Services Access."
+  default     = "172.30.0.0"
+}
+
+variable "private_services_range_prefix_length" {
+  type        = number
+  description = "Prefix length for the Private Services Access range."
+  default     = 16
+}
+
+variable "vpc_connector_cidr" {
+  type        = string
+  description = "Unused /28 CIDR for the backend Serverless VPC Access connector."
+  default     = "172.31.0.0/28"
+}
+
 
 variable "firebase_site_id" {
   type        = string

--- a/infra/modules/postgresql/main.tf
+++ b/infra/modules/postgresql/main.tf
@@ -32,7 +32,8 @@ resource "google_sql_database_instance" "default" {
     }
 
     ip_configuration {
-      ipv4_enabled = true # Easy connectivity from Cloud Run without VPC peering complexity
+      ipv4_enabled    = false
+      private_network = var.private_network
     }
   }
   

--- a/infra/modules/postgresql/variables.tf
+++ b/infra/modules/postgresql/variables.tf
@@ -15,8 +15,8 @@
 variable "project_id" {}
 variable "region" {}
 variable "private_network" {
-	type        = string
-	description = "VPC self link used for the Cloud SQL private IP address."
+  type        = string
+  description = "VPC self link used for the Cloud SQL private IP address."
 }
 variable "db_name" { default = "creative_studio" }
 variable "db_user" { default = "studio_user" }

--- a/infra/modules/postgresql/variables.tf
+++ b/infra/modules/postgresql/variables.tf
@@ -14,6 +14,10 @@
 
 variable "project_id" {}
 variable "region" {}
+variable "private_network" {
+	type        = string
+	description = "VPC self link used for the Cloud SQL private IP address."
+}
 variable "db_name" { default = "creative_studio" }
 variable "db_user" { default = "studio_user" }
 variable "db_password" { sensitive = true }

--- a/infra/modules/private-networking/main.tf
+++ b/infra/modules/private-networking/main.tf
@@ -21,7 +21,6 @@ resource "google_compute_global_address" "private_services" {
 }
 
 resource "google_service_networking_connection" "private_services" {
-  project                 = var.network_project_id
   network                 = local.network_self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_services.name]

--- a/infra/modules/private-networking/main.tf
+++ b/infra/modules/private-networking/main.tf
@@ -1,0 +1,41 @@
+resource "google_compute_network" "this" {
+  count = var.network_self_link == "" ? 1 : 0
+
+  name                    = var.network_name
+  project                 = var.network_project_id
+  auto_create_subnetworks = false
+}
+
+locals {
+  network_self_link = var.network_self_link != "" ? var.network_self_link : google_compute_network.this[0].self_link
+}
+
+resource "google_compute_global_address" "private_services" {
+  name          = var.private_services_range_name
+  project       = var.network_project_id
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  address       = var.private_services_range_address
+  prefix_length = var.private_services_range_prefix_length
+  network       = local.network_self_link
+}
+
+resource "google_service_networking_connection" "private_services" {
+  project                 = var.network_project_id
+  network                 = local.network_self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_services.name]
+}
+
+resource "google_vpc_access_connector" "backend" {
+  name          = var.vpc_connector_name
+  project       = var.project_id
+  region        = var.region
+  network       = local.network_self_link
+  ip_cidr_range = var.vpc_connector_cidr
+
+  min_instances = 2
+  max_instances = 3
+
+  depends_on = [google_service_networking_connection.private_services]
+}

--- a/infra/modules/private-networking/outputs.tf
+++ b/infra/modules/private-networking/outputs.tf
@@ -1,0 +1,9 @@
+output "network_self_link" {
+  description = "The VPC used by Cloud SQL private IP and the VPC Access connector."
+  value       = local.network_self_link
+}
+
+output "vpc_connector_id" {
+  description = "The backend Serverless VPC Access connector ID."
+  value       = google_vpc_access_connector.backend.id
+}

--- a/infra/modules/private-networking/variables.tf
+++ b/infra/modules/private-networking/variables.tf
@@ -1,0 +1,51 @@
+variable "project_id" {
+  type        = string
+  description = "The project that hosts Cloud Run and the VPC Access connector."
+}
+
+variable "network_project_id" {
+  type        = string
+  description = "The project that owns the VPC and Private Services Access resources."
+}
+
+variable "region" {
+  type        = string
+  description = "The region for the Serverless VPC Access connector."
+}
+
+variable "network_name" {
+  type        = string
+  description = "Name for the dedicated VPC when network_self_link is not supplied."
+}
+
+variable "network_self_link" {
+  type        = string
+  description = "Approved existing VPC self link. Leave empty to create a dedicated VPC."
+  default     = ""
+}
+
+variable "private_services_range_name" {
+  type        = string
+  description = "Name of the global range reserved for Private Services Access."
+}
+
+variable "private_services_range_address" {
+  type        = string
+  description = "Unused RFC 1918 base address for the Private Services Access range."
+}
+
+variable "private_services_range_prefix_length" {
+  type        = number
+  description = "Prefix length for the Private Services Access range."
+  default     = 16
+}
+
+variable "vpc_connector_name" {
+  type        = string
+  description = "Name of the backend Serverless VPC Access connector."
+}
+
+variable "vpc_connector_cidr" {
+  type        = string
+  description = "Unused /28 CIDR reserved for the Serverless VPC Access connector."
+}


### PR DESCRIPTION
## Summary

Adds a persistent red warning banner to Creative Studio’s authenticated frontend experience.

The banner informs trial users that the application is a trial environment and that they must not enter, upload, or generate sensitive, confidential, or personal information.

## Motivation

Creative Studio is currently running as an internal, time-boxed trial. Users need a clear and consistent reminder that the environment is not appropriate for sensitive data before they use generation, upload, or other application features.

## Change

- Adds a red, accessible warning banner to the root Angular application shell.
- Displays the following message:

  ```text
  Trial environment: Do not enter, upload, or generate sensitive, confidential, or personal information.
  ```

- Shows the banner on authenticated Creative Studio routes, including admin routes.
- Excludes login, password-reset, and support-ticket routes, which do not render the standard application shell.

## Deployment Details

```text
Project: iconic-ds-creative-studio-dev
Frontend: https://iconic-ds-creative-studio-dev.web.app
```

The frontend was deployed through the existing Cloud Build and Firebase Hosting workflow.

## Test Plan

- Confirmed the banner branch source was synced to Cloud Shell before validation and deployment.
- `npm run compile`: passed.
- `npm run lint`: passed with `0` errors.
  - The repository retains 335 pre-existing lint warnings outside the scope of this change.
- `git diff --check`: passed.
- Confirmed the frontend Cloud Build and Firebase Hosting deployment completed successfully.
- Manually verified the deployed application displays the red warning banner above the standard application header.

## Follow-up Work

### Security remediation — priority

- Immediately verify whether `/api/workflows-executor/*` can be reached without authenticated application-level identity and invoke Vertex AI. If confirmed, require authentication and authorization before execution, then add rate limits, per-user quotas, spend budgets, and alerting.
- Immediately remove raw `Authorization` header logging from the workflow executor. Review the affected log retention/access scope and rotate or revoke credentials/sessions as advised by Security.
- Verify whether `/api/workbench/render` is externally reachable without authentication. If confirmed, require authenticated authorization and restrict source media to application-owned, authorized `gs://` objects or an explicit allowlist. Do not fetch arbitrary caller-provided URLs.
- Configure and enforce `IDENTITY_PLATFORM_ALLOWED_ORGS` for approved internal domains/groups. Verify the live Identity Platform provider configuration and reject unapproved identities before just-in-time user provisioning.
- Correct the production CORS configuration mismatch between `FRONTEND_URL` and Terraform-provided `CORS_ORIGINS`, then test the deployed allowlist.
- Replace project-level `roles/storage.objectAdmin` on the backend runtime service account with bucket-scoped, least-privilege permissions.
- Add browser hardening headers: CSP, `X-Content-Type-Options`, referrer policy, and permissions policy.

### Access architecture

- Assess replacing Firebase Hosting with a private frontend deployment behind an external HTTPS load balancer and IAP.
- Note: Firebase Hosting cannot simply be placed behind IAP as a protected origin. Achieving IAP enforcement requires hosting the frontend behind infrastructure that supports IAP, such as Cloud Run behind an external Application Load Balancer using a serverless NEG, with backend access aligned to the same perimeter.
- Confirm that direct Cloud Run URLs and alternate hosting paths cannot bypass the chosen access boundary.

### Trial operations

- Define a teardown date and execute the documented teardown when the trial ends.
- Formalize the Cloud Run Job seeding path in Terraform/bootstrap.
- Update `PRIVATE_SQL_DEPLOYMENT.md` with the active Cloud Build connection name and seeding procedure.