### PR TITLE
fix(bootstrap): select Cloud SQL Proxy binary for the host architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ local/
 genmedia-agent-demos
 .gemini
 .agents
+
+# Cloud SQL Auth Proxy binary downloaded by bootstrap.sh
+cloud-sql-proxy

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -151,13 +151,32 @@ start_sql_proxy() {
     export INSTANCE_CONNECTION_NAME="$DB_INSTANCE_NAME"
 
     # 2. Download Proxy (if missing)
+    # Select the binary for the host OS/architecture. Hardcoding linux.amd64
+    # works in Cloud Shell but fails elsewhere with "exec format error".
     if [ ! -f "cloud-sql-proxy" ]; then
-        curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.8.0/cloud-sql-proxy.linux.amd64
+        local PROXY_OS PROXY_ARCH
+        case "$(uname -s)" in
+            Darwin) PROXY_OS="darwin" ;;
+            Linux)  PROXY_OS="linux" ;;
+            *) fail "Unsupported OS for Cloud SQL Proxy: $(uname -s)" ;;
+        esac
+        case "$(uname -m)" in
+            arm64|aarch64) PROXY_ARCH="arm64" ;;
+            x86_64|amd64)  PROXY_ARCH="amd64" ;;
+            *) fail "Unsupported architecture for Cloud SQL Proxy: $(uname -m)" ;;
+        esac
+        info "Downloading Cloud SQL Proxy for ${PROXY_OS}.${PROXY_ARCH}..."
+        curl -fsSL -o cloud-sql-proxy \
+          "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.8.0/cloud-sql-proxy.${PROXY_OS}.${PROXY_ARCH}" \
+          || fail "Failed to download Cloud SQL Proxy."
         chmod +x cloud-sql-proxy
     fi
 
     # 3. Start Proxy in Background (Port 5432)
-    ./cloud-sql-proxy --address 0.0.0.0 --port 5432 "$DB_INSTANCE_NAME" > /dev/null 2>&1 &
+    # Keep proxy output so startup failures can be diagnosed.
+    PROXY_LOG="${TMPDIR:-/tmp}/cloud-sql-proxy.log"
+    export PROXY_LOG
+    ./cloud-sql-proxy --address 0.0.0.0 --port 5432 "$DB_INSTANCE_NAME" > "$PROXY_LOG" 2>&1 &
     PROXY_PID=$!
     export PROXY_PID
     
@@ -172,7 +191,11 @@ start_sql_proxy() {
         sleep 1
     done
     echo
-    warn "Proxy connection check timed out, but proceeding..."
+    # Continuing here only defers the failure: seeding then dies with an
+    # opaque asyncpg "Connect call failed ('127.0.0.1', 5432)" traceback.
+    warn "Proxy failed to start. Last 20 lines of ${PROXY_LOG}:"
+    tail -20 "$PROXY_LOG" 2>/dev/null || echo "   (no proxy log written)"
+    fail "Cloud SQL Proxy did not become ready on 127.0.0.1:5432."
 }
 
 stop_sql_proxy() {


### PR DESCRIPTION
## Problem

`bootstrap.sh` unconditionally downloads `cloud-sql-proxy.linux.amd64`:

```bash
curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.8.0/cloud-sql-proxy.linux.amd64
```

That is correct for Cloud Shell, which the README recommends, but it breaks any other host. On macOS arm64 the download succeeds and the binary then cannot execute:

```
$ ./cloud-sql-proxy --version
zsh: exec format error: ./cloud-sql-proxy
$ file cloud-sql-proxy
cloud-sql-proxy: ELF 64-bit LSB executable, x86-64, ...
```

Two things made this hard to diagnose:

1. Proxy output goes to `/dev/null`, so the exec failure is invisible.
2. The readiness loop warns and continues (`Proxy connection check timed out, but proceeding...`).

So the first real symptom arrives in step 13, as a traceback that points at the database rather than the proxy:

```
ConnectionRefusedError: [Errno 61] Connect call failed ('127.0.0.1', 5432)
❌  Python bootstrap script failed.
```

Someone hitting this would reasonably start debugging Cloud SQL networking, IAM, or the instance itself. All of those are fine.

## Changes

- Detect OS and architecture with `uname`, download the matching binary (`darwin`/`linux` × `arm64`/`amd64`), and fail with a clear message on anything unsupported.
- Use `curl -fsSL` so a failed download is caught instead of leaving an HTML error page where the binary should be.
- Write proxy output to `$TMPDIR/cloud-sql-proxy.log` rather than discarding it.
- Fail at the readiness check and print the tail of that log, instead of continuing into the misleading downstream error.
- Add the downloaded binary (~31 MB) to `.gitignore` — it was untracked and easy to commit by accident.

## Verification

On macOS arm64:

```
cloud-sql-proxy version 2.8.0+darwin.arm64
Authorizing with Application Default Credentials
Listening on 127.0.0.1:5432
The proxy has started successfully and is ready for new connections!
```

Ready in roughly two seconds, and step 13 seeding then completes normally (18 media templates, 43 source assets). `bash -n bootstrap.sh` passes. No change in behaviour on linux/amd64, which still resolves to the same URL as before.

## Note

Found while deploying Creative Studio to a GCP project from a Mac. Happy to adjust the approach — for instance failing fast with a "please use Cloud Shell" message instead — if supporting non-Linux hosts isn't intended.