### PR TITLE
fix(admin): bind [pageIndex] so the paginator stays on the page it fetched

### DIFF
--- a/frontend/src/app/admin/media-gallery-management/media-gallery-management.component.html
+++ b/frontend/src/app/admin/media-gallery-management/media-gallery-management.component.html
@@ -269,6 +269,7 @@
     <mat-paginator
       [length]="totalItems"
       [pageSize]="limit"
+      [pageIndex]="currentPageIndex"
       [pageSizeOptions]="[5, 10, 25, 50]"
       (page)="handlePageEvent($event)"
       class="!bg-transparent"

--- a/frontend/src/app/admin/media-gallery-management/media-gallery-management.component.spec.ts
+++ b/frontend/src/app/admin/media-gallery-management/media-gallery-management.component.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatChipsModule} from '@angular/material/chips';
+import {MatNativeDateModule} from '@angular/material/core';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatPaginator, MatPaginatorModule} from '@angular/material/paginator';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatSelectModule} from '@angular/material/select';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSortModule} from '@angular/material/sort';
+import {MatTableModule} from '@angular/material/table';
+import {MatTooltipModule} from '@angular/material/tooltip';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {RouterModule, provideRouter} from '@angular/router';
+import {Subject, of} from 'rxjs';
+
+import {GalleryItem} from '../../common/models/gallery-item.model';
+import {GallerySearchDto} from '../../common/models/search.model';
+import {TagsService} from '../../common/services/tags.service';
+import {GalleryService} from '../../gallery/gallery.service';
+import {AdminDashboardService} from '../../services/admin/admin-dashboard.service';
+import {MediaGalleryManagementComponent} from './media-gallery-management.component';
+
+const TOTAL_ITEMS = 723;
+
+interface GalleryResponse {
+  data: GalleryItem[];
+  count: number;
+}
+
+describe('MediaGalleryManagementComponent', () => {
+  let component: MediaGalleryManagementComponent;
+  let fixture: ComponentFixture<MediaGalleryManagementComponent>;
+  let fetchImages: jasmine.Spy;
+
+  /**
+   * Requests the component has made but that have not answered yet. Real
+   * fetches take a turn of the event loop to come back, and change detection
+   * runs in the meantime; a synchronous `of(...)` stub hides that window and
+   * with it every bug that lives in the loading state.
+   */
+  let inFlight: Array<{
+    body: GallerySearchDto;
+    response: Subject<GalleryResponse>;
+  }>;
+
+  function rowsFor(body: GallerySearchDto): GalleryItem[] {
+    const offset = body.offset ?? 0;
+    return Array.from({length: body.limit ?? 10}, (_, i) => ({
+      id: offset + i,
+      itemType: 'media_item',
+    })) as unknown as GalleryItem[];
+  }
+
+  /** Answers the oldest outstanding request and re-renders. */
+  async function respond(): Promise<GallerySearchDto> {
+    const request = inFlight.shift();
+    if (!request) {
+      throw new Error('respond() called with no request in flight');
+    }
+    request.response.next({
+      data: rowsFor(request.body),
+      count: TOTAL_ITEMS,
+    });
+    request.response.complete();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return request.body;
+  }
+
+  /** The paginator sits inside an *ngIf, so it must be re-queried each time. */
+  function paginator(): MatPaginator | null {
+    const found = fixture.debugElement.query(
+      el => el.componentInstance instanceof MatPaginator,
+    );
+    return found ? (found.componentInstance as MatPaginator) : null;
+  }
+
+  function previousPageButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector(
+      '.mat-mdc-paginator-navigation-previous',
+    );
+  }
+
+  function nextPageButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector(
+      '.mat-mdc-paginator-navigation-next',
+    );
+  }
+
+  function rangeLabel(): string {
+    return (
+      fixture.nativeElement
+        .querySelector('.mat-mdc-paginator-range-label')
+        ?.textContent?.trim() ?? ''
+    );
+  }
+
+  /** Clicks "next page" and lets the resulting request come back. */
+  async function goToNextPage(): Promise<GallerySearchDto> {
+    nextPageButton()!.click();
+    // The click leaves a request outstanding. Rendering here is what the
+    // browser does too, and it is what tears the paginator down.
+    fixture.detectChanges();
+    return respond();
+  }
+
+  beforeEach(async () => {
+    inFlight = [];
+    fetchImages = jasmine
+      .createSpy('fetchImages')
+      .and.callFake((body: GallerySearchDto) => {
+        const response = new Subject<GalleryResponse>();
+        inFlight.push({body, response});
+        return response.asObservable();
+      });
+
+    await TestBed.configureTestingModule({
+      declarations: [MediaGalleryManagementComponent],
+      imports: [
+        FormsModule,
+        MatButtonModule,
+        MatCheckboxModule,
+        MatChipsModule,
+        MatDatepickerModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatNativeDateModule,
+        MatPaginatorModule,
+        MatProgressSpinnerModule,
+        MatSelectModule,
+        MatSnackBarModule,
+        MatSortModule,
+        MatTableModule,
+        MatTooltipModule,
+        NoopAnimationsModule,
+        RouterModule,
+      ],
+      providers: [
+        provideRouter([]),
+        {provide: GalleryService, useValue: {fetchImages}},
+        {
+          provide: TagsService,
+          useValue: {
+            getTags: jasmine
+              .createSpy('getTags')
+              .and.returnValue(of({data: [], count: 0})),
+          },
+        },
+        {
+          provide: AdminDashboardService,
+          useValue: {
+            cleanupStuckJobs: jasmine
+              .createSpy('cleanupStuckJobs')
+              .and.returnValue(of({message: 'ok'})),
+          },
+        },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MediaGalleryManagementComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await respond();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the first page with the previous-page button disabled', () => {
+    expect(paginator()!.pageIndex).toBe(0);
+    expect(previousPageButton()!.disabled).toBeTrue();
+  });
+
+  it('hides the paginator while a page is loading', () => {
+    nextPageButton()!.click();
+    fixture.detectChanges();
+
+    // Not a requirement, just the fact that makes the rest of these tests
+    // necessary: the paginator is destroyed and rebuilt on every fetch, so
+    // it cannot be trusted to remember which page it was on.
+    expect(paginator()).toBeNull();
+  });
+
+  it('keeps the paginator on the page that was fetched', async () => {
+    const request = await goToNextPage();
+
+    expect(request.offset).toBe(10);
+    expect(component.currentPageIndex).toBe(1);
+    expect(paginator()!.pageIndex).toBe(1);
+    expect(previousPageButton()!.disabled).toBeFalse();
+    expect(rangeLabel()).toContain('11');
+  });
+
+  it('goes back a page when the previous-page button is clicked', async () => {
+    await goToNextPage();
+    const forward = await goToNextPage();
+    expect(forward.offset).toBe(20);
+
+    previousPageButton()!.click();
+    fixture.detectChanges();
+    const back = await respond();
+
+    expect(back.offset).toBe(10);
+    expect(paginator()!.pageIndex).toBe(1);
+  });
+
+  it('returns to the first page when a filter changes', async () => {
+    await goToNextPage();
+
+    component.filterStatus = 'completed';
+    component.applyFilters();
+    fixture.detectChanges();
+    const request = await respond();
+
+    expect(request.offset).toBe(0);
+    expect(paginator()!.pageIndex).toBe(0);
+    expect(previousPageButton()!.disabled).toBeTrue();
+  });
+
+  it('returns to the first page when the page size changes', async () => {
+    await goToNextPage();
+
+    paginator()!.page.emit({pageIndex: 1, pageSize: 25, length: TOTAL_ITEMS});
+    fixture.detectChanges();
+    const request = await respond();
+
+    expect(request.limit).toBe(25);
+    expect(request.offset).toBe(0);
+    expect(paginator()!.pageIndex).toBe(0);
+  });
+});

--- a/frontend/src/app/admin/tags-management/tags-management.component.html
+++ b/frontend/src/app/admin/tags-management/tags-management.component.html
@@ -98,7 +98,8 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
-<mat-paginator [length]="totalItems" [pageSize]="limit" [pageSizeOptions]="[5, 10, 20]" (page)="handlePageEvent($event)"
+<mat-paginator [length]="totalItems" [pageSize]="limit" [pageIndex]="currentPageIndex"
+  [pageSizeOptions]="[5, 10, 20]" (page)="handlePageEvent($event)"
   class="bg-neutral-950 text-white"></mat-paginator>
   </div>
 

--- a/frontend/src/app/admin/tags-management/tags-management.component.spec.ts
+++ b/frontend/src/app/admin/tags-management/tags-management.component.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatPaginator, MatPaginatorModule} from '@angular/material/paginator';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatTableModule} from '@angular/material/table';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Subject} from 'rxjs';
+
+import {
+  PaginationResponseDto,
+  TagModel,
+  TagsService,
+} from '../../common/services/tags.service';
+import {WorkspaceStateService} from '../../services/workspace/workspace-state.service';
+import {TagsManagementComponent} from './tags-management.component';
+
+const WORKSPACE_ID = 7;
+const TOTAL_ITEMS = 95;
+
+describe('TagsManagementComponent', () => {
+  let component: TagsManagementComponent;
+  let fixture: ComponentFixture<TagsManagementComponent>;
+  let getTags: jasmine.Spy;
+
+  /**
+   * Outstanding requests. Answering them on a later turn of the event loop
+   * (rather than synchronously) is what lets change detection observe
+   * `isLoading === true` and tear the paginator out of the DOM, which is the
+   * condition the pagination bugs live in.
+   */
+  let inFlight: Array<{
+    page: number;
+    pageSize: number;
+    response: Subject<PaginationResponseDto<TagModel>>;
+  }>;
+
+  async function respond(): Promise<{page: number; pageSize: number}> {
+    const request = inFlight.shift();
+    if (!request) {
+      throw new Error('respond() called with no request in flight');
+    }
+    request.response.next({
+      data: Array.from({length: request.pageSize}, (_, i) => ({
+        id: (request.page - 1) * request.pageSize + i,
+        name: `tag-${i}`,
+        workspaceId: WORKSPACE_ID,
+        color: '#ffffff',
+      })),
+      count: TOTAL_ITEMS,
+      page: request.page,
+      pageSize: request.pageSize,
+      totalPages: Math.ceil(TOTAL_ITEMS / request.pageSize),
+    });
+    request.response.complete();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return {page: request.page, pageSize: request.pageSize};
+  }
+
+  /** The paginator sits inside an *ngIf, so it must be re-queried each time. */
+  function paginator(): MatPaginator | null {
+    const found = fixture.debugElement.query(
+      el => el.componentInstance instanceof MatPaginator,
+    );
+    return found ? (found.componentInstance as MatPaginator) : null;
+  }
+
+  function previousPageButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector(
+      '.mat-mdc-paginator-navigation-previous',
+    );
+  }
+
+  function nextPageButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector(
+      '.mat-mdc-paginator-navigation-next',
+    );
+  }
+
+  async function goToNextPage(): Promise<{page: number; pageSize: number}> {
+    nextPageButton()!.click();
+    fixture.detectChanges();
+    return respond();
+  }
+
+  beforeEach(async () => {
+    inFlight = [];
+    getTags = jasmine
+      .createSpy('getTags')
+      .and.callFake(
+        (
+          _workspaceId: number,
+          _search: string | undefined,
+          page = 1,
+          pageSize = 10,
+        ) => {
+          const response = new Subject<PaginationResponseDto<TagModel>>();
+          inFlight.push({page, pageSize, response});
+          return response.asObservable();
+        },
+      );
+
+    await TestBed.configureTestingModule({
+      declarations: [TagsManagementComponent],
+      imports: [
+        FormsModule,
+        MatButtonModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatPaginatorModule,
+        MatProgressSpinnerModule,
+        MatSnackBarModule,
+        MatTableModule,
+        NoopAnimationsModule,
+      ],
+      providers: [{provide: TagsService, useValue: {getTags}}],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    TestBed.inject(WorkspaceStateService).setActiveWorkspaceId(WORKSPACE_ID);
+
+    fixture = TestBed.createComponent(TagsManagementComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await respond();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the first page with the previous-page button disabled', () => {
+    expect(paginator()!.pageIndex).toBe(0);
+    expect(previousPageButton()!.disabled).toBeTrue();
+  });
+
+  // The paginator is destroyed and rebuilt on every load, so without
+  // [pageIndex] bound to currentPageIndex it returns on page 0 and disables
+  // its own previous-page button, stranding the user.
+  it('keeps the paginator on the page that was fetched', async () => {
+    const request = await goToNextPage();
+
+    expect(request.page).toBe(2);
+    expect(component.currentPageIndex).toBe(1);
+    expect(paginator()!.pageIndex).toBe(1);
+    expect(previousPageButton()!.disabled).toBeFalse();
+  });
+
+  it('goes back a page when the previous-page button is clicked', async () => {
+    await goToNextPage();
+    const forward = await goToNextPage();
+    expect(forward.page).toBe(3);
+
+    previousPageButton()!.click();
+    fixture.detectChanges();
+    const back = await respond();
+
+    expect(back.page).toBe(2);
+    expect(paginator()!.pageIndex).toBe(1);
+  });
+
+  // Material recomputes pageIndex on a page-size change to keep the first
+  // visible row on screen, so the event does not arrive with pageIndex 0.
+  it('returns to the first page when the page size changes', async () => {
+    await goToNextPage();
+    await goToNextPage();
+
+    paginator()!.page.emit({pageIndex: 1, pageSize: 20, length: TOTAL_ITEMS});
+    fixture.detectChanges();
+    const request = await respond();
+
+    expect(request.pageSize).toBe(20);
+    expect(request.page).toBe(1);
+    expect(component.currentPageIndex).toBe(0);
+    expect(paginator()!.pageIndex).toBe(0);
+    expect(previousPageButton()!.disabled).toBeTrue();
+  });
+});

--- a/frontend/src/app/admin/tags-management/tags-management.component.ts
+++ b/frontend/src/app/admin/tags-management/tags-management.component.ts
@@ -83,6 +83,11 @@ export class TagsManagementComponent implements OnInit {
       if (this.paginator) {
         this.paginator.pageIndex = 0;
       }
+      // Material recomputes pageIndex to keep the first visible row in view,
+      // so event.pageIndex is not 0 here. Loading it would undo the reset
+      // above the moment loadTags reassigns currentPageIndex.
+      this.loadTags(0);
+      return;
     }
     this.loadTags(event.pageIndex);
   }


### PR DESCRIPTION
Fixes #278

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

(No documentation changes needed: this is a two-binding bug fix with no API, config, or user-facing feature surface.)

## What was broken

On `/admin/media-gallery`, advancing to page 2 left the paginator showing `1 – 25 of 723` with its previous-page arrow greyed out, while the table below displayed page 2's rows. There was no way back, and clicking next again re-requested the same offset. `/admin/tags` had the same defect. Details and repro steps are in #278.

## Cause

In both components the `<table>` and the `<mat-paginator>` share one wrapper gated on the loading flag, and the fetch sets `isLoading = true` before awaiting. Every page change therefore destroys the paginator and builds a new one when the response arrives. Neither template bound `[pageIndex]`, so the replacement always came back on page 0 — and `MatPaginator` disables its own previous-page button whenever `pageIndex === 0`.

## Change

Bind `[pageIndex]` to the `currentPageIndex` that both components already track and already assign on success:

```html
[pageIndex]="currentPageIndex"
```

This is exactly what `users-management.component.html` and `source-assets-management.component.html` already do with the identical loading wrapper, which is why those two tables were never affected. The fix makes the two outliers consistent with them rather than introducing a new pattern.

`tags-management` needed one more line: its page-size handler reset `currentPageIndex` to 0 and then called `loadTags(event.pageIndex)`. Material recomputes that index to keep the first visible row on screen, so it is not 0, and `loadTags` reassigned `currentPageIndex` from it and undid the reset. It now loads page 0 explicitly, matching `media-gallery-management`'s `resetPaginationAndFetch()` behaviour.

## Tests

Adds specs for both components (neither had one): 12 tests, and no changes to any existing spec. Verified in both directions against this branch's base — the specs produce 5 failures on unmodified `main` and pass with the fix.

One note for anyone extending these specs. The stubs deliberately answer each request on a later turn of the event loop, via a `Subject` per request rather than a synchronous `of(...)`. With a synchronous stub, change detection never observes `isLoading === true`, the `*ngIf` never tears the paginator down, and the surviving instance keeps its own correct `pageIndex` — so the tests pass against the broken code. My first attempt did exactly that and went green on the bug, which is what the deferred stub exists to prevent.

## Not included

While confirming the scope I found an adjacent issue I have left alone to keep this reviewable, described at the end of #278: `media-templates-management.component.ts` assigns `dataSource.paginator = this.paginator` in `ngAfterViewInit` while `isLoading` starts `true`, so it assigns `undefined` once and never reassigns. Its client-side paging looks inert rather than merely wrong on page 2. Unverified against a running app, and happy to file it separately or fold it in if you'd prefer.
